### PR TITLE
remove tap as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,12 @@ output:
 
 ```
 # Testcode:
-# 0 'use strict';
-# 1
-# 2 var foobar = 'foobar';
-# 3 console.log(foobar);assert.deepEqual(foobar, "foobar");
+# 0 var assert = require("assert");
+# 1 "use strict";
+# 2
+# 3 var foobar = 'foobar';
+# 4 console.log(foobar);assert.deepEqual(foobar, "foobar");
 foobar
-TAP version 13
-ok 1 - should be equivalent
-1..1
-# time=925.021ms
 ```
 
 ## Sample tests

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "babel-plugin-transform-rename-import": "^1.0.0",
     "babel-traverse": "^6.4.5",
     "docopt": "~0.6.2",
-    "remark": "^3.2.2",
-    "tap": "^5.1.1"
+    "remark": "^3.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",

--- a/src/readme-test.js
+++ b/src/readme-test.js
@@ -13,8 +13,7 @@ export default function run () {
 }
 
 function evalCode (code) {
-  var tapPath = path.join(path.join(__dirname, '../node_modules/tap'))
-  code = `var assert = require("${tapPath}");\n` + code
+  code = `var assert = require("assert");\n` + code
   printCode(code)
 
   process.exit(spawnSync('node', ['-e', code], {


### PR DESCRIPTION
It was dependent on npm 2.x. npm 3 moves the module somewhere out of my
control.