### PR TITLE
Support string and conditional package.json exports

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -50,7 +50,7 @@ export async function processMarkdown(filePath, options = {}) {
   if (pkgPath) {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
     if (pkg.name) {
-      const mainEntry = options.main || pkg.main || pkg.exports?.["."] || "./index.js";
+      const mainEntry = options.main || resolveMainEntry(pkg) || "./index.js";
       packageName = pkg.name;
       localPath = path.resolve(path.dirname(pkgPath), mainEntry);
     }
@@ -265,4 +265,46 @@ function findPackageJson(dir) {
     if (parent === current) return null;
     current = parent;
   }
+}
+
+/**
+ * Resolve a package's main entry point from its package.json.
+ *
+ * Handles `main`, plus the various shapes of `exports`:
+ *   - string:          "exports": "./lib/main.js"
+ *   - subpath map:     "exports": { ".": "./lib/main.js" }
+ *   - conditional:     "exports": { "import": "./esm.js", "require": "./cjs.js" }
+ *   - nested:          "exports": { ".": { "import": "./esm.js" } }
+ *
+ * Returns null if no entry can be determined.
+ */
+export function resolveMainEntry(pkg) {
+  if (pkg.main) return pkg.main;
+
+  const exp = pkg.exports;
+  if (!exp) return null;
+  if (typeof exp === "string") return exp;
+  if (typeof exp !== "object") return null;
+
+  // If any key starts with ".", this is a subpath map and the root export
+  // lives at "."; otherwise the object itself is the conditional map.
+  const isSubpathMap = Object.keys(exp).some((k) => k.startsWith("."));
+  const root = isSubpathMap ? exp["."] : exp;
+
+  return resolveExportCondition(root);
+}
+
+function resolveExportCondition(node) {
+  if (node == null) return null;
+  if (typeof node === "string") return node;
+  if (typeof node !== "object") return null;
+
+  // Prefer import > default > require
+  for (const key of ["import", "default", "require"]) {
+    if (key in node) {
+      const resolved = resolveExportCondition(node[key]);
+      if (resolved) return resolved;
+    }
+  }
+  return null;
 }

--- a/test/fixtures/pkg-string-exports/lib/main.js
+++ b/test/fixtures/pkg-string-exports/lib/main.js
@@ -1,0 +1,1 @@
+export const hello = () => "world";

--- a/test/fixtures/pkg-string-exports/package.json
+++ b/test/fixtures/pkg-string-exports/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@fixture/string-exports",
+  "type": "module",
+  "exports": "./lib/main.js"
+}

--- a/test/fixtures/pkg-string-exports/readme.md
+++ b/test/fixtures/pkg-string-exports/readme.md
@@ -1,0 +1,6 @@
+# string-exports fixture
+
+```javascript test
+import { hello } from "@fixture/string-exports";
+hello(); //=> "world"
+```

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { processMarkdown, run } from "../src/run.js";
+import { processMarkdown, resolveMainEntry, run } from "../src/run.js";
 
 const fixturesDir = new URL("./fixtures/", import.meta.url).pathname;
 
@@ -19,6 +19,18 @@ describe("processMarkdown", () => {
     assert.ok(units.length >= 1);
     assert.ok(units[0].code.includes("assert.throws("));
   });
+
+  it("rewrites imports when package.json exports is a string", async () => {
+    const readme = path.join(fixturesDir, "pkg-string-exports/readme.md");
+    const expected = path.join(fixturesDir, "pkg-string-exports/lib/main.js");
+    const units = await processMarkdown(readme);
+    const code = units.map((u) => u.code).join("\n");
+    assert.ok(
+      code.includes(expected),
+      `expected import rewritten to ${expected}, got:\n${code}`,
+    );
+    assert.ok(!code.includes('"@fixture/string-exports"'));
+  });
 });
 
 describe("run", () => {
@@ -30,5 +42,90 @@ describe("run", () => {
   it("executes throws.md successfully", async () => {
     const result = await run(path.join(fixturesDir, "throws.md"));
     assert.equal(result.exitCode, 0);
+  });
+
+  it("executes a package with exports as string", async () => {
+    const result = await run(
+      path.join(fixturesDir, "pkg-string-exports/readme.md"),
+    );
+    assert.equal(result.exitCode, 0, result.stderr);
+  });
+});
+
+describe("resolveMainEntry", () => {
+  it("returns pkg.main when set", () => {
+    assert.equal(resolveMainEntry({ main: "./foo.js" }), "./foo.js");
+  });
+
+  it("pkg.main takes precedence over exports", () => {
+    assert.equal(
+      resolveMainEntry({ main: "./foo.js", exports: "./bar.js" }),
+      "./foo.js",
+    );
+  });
+
+  it("returns exports when it is a string", () => {
+    assert.equal(
+      resolveMainEntry({ exports: "./lib/main.js" }),
+      "./lib/main.js",
+    );
+  });
+
+  it("returns exports['.'] when it is a subpath map", () => {
+    assert.equal(
+      resolveMainEntry({
+        exports: { ".": "./lib/main.js", "./sub": "./sub.js" },
+      }),
+      "./lib/main.js",
+    );
+  });
+
+  it("resolves conditional exports at a subpath", () => {
+    assert.equal(
+      resolveMainEntry({
+        exports: { ".": { import: "./esm.js", require: "./cjs.js" } },
+      }),
+      "./esm.js",
+    );
+  });
+
+  it("resolves bare conditional exports (no subpaths)", () => {
+    assert.equal(
+      resolveMainEntry({
+        exports: { import: "./esm.js", require: "./cjs.js" },
+      }),
+      "./esm.js",
+    );
+  });
+
+  it("prefers import > default > require", () => {
+    assert.equal(
+      resolveMainEntry({
+        exports: { require: "./cjs.js", default: "./default.js" },
+      }),
+      "./default.js",
+    );
+    assert.equal(
+      resolveMainEntry({ exports: { require: "./cjs.js" } }),
+      "./cjs.js",
+    );
+  });
+
+  it("resolves nested conditions", () => {
+    assert.equal(
+      resolveMainEntry({
+        exports: {
+          ".": {
+            import: { types: "./types.d.ts", default: "./esm.js" },
+          },
+        },
+      }),
+      "./esm.js",
+    );
+  });
+
+  it("returns null when no entry can be determined", () => {
+    assert.equal(resolveMainEntry({}), null);
+    assert.equal(resolveMainEntry({ exports: null }), null);
   });
 });


### PR DESCRIPTION
## Summary

- Resolve the module main entry through a new `resolveMainEntry` helper that handles every common shape of `package.json` `exports`:
  - **string** (`"exports": "./lib/main.js"`)
  - **subpath map** (`"exports": { ".": "./lib/main.js" }`)
  - **bare conditional** (`"exports": { "import": "./esm.js", "require": "./cjs.js" }`)
  - **subpath + conditional nesting** (`"exports": { ".": { "import": { "default": "./esm.js" } } }`)
- Preserves the existing `options.main > pkg.main > pkg.exports > "./index.js"` precedence.

## Why

`src/run.js` used `pkg.exports?.["."]` to pull the root export, which silently returns `undefined` for the string form and for bare conditional maps, falling through to `./index.js`. This package's own `package.json` has `"exports": "./src/index.js"`, so any README that imports `readme-assert` by name would be rewritten to a nonexistent path. Reproduced with a fixture pkg whose `exports` is `./lib/main.js` — before: import rewritten to `.../index.js`; after: `.../lib/main.js`.

## Test plan

- [x] New `resolveMainEntry` unit tests cover string / subpath / conditional / nested / null cases (9 cases).
- [x] New integration fixture `test/fixtures/pkg-string-exports/` exercises the full `processMarkdown` + `run` path through an ESM package with `"exports": "./lib/main.js"`.
- [x] `node --test test/*.test.js` — 55 tests pass (11 new).
- [x] `pnpm -r test` — all 10 workspace example packages still pass.