### PR TITLE
Preserve line numbers when transforming console.log assertions

### DIFF
--- a/src/comment-to-assert.js
+++ b/src/comment-to-assert.js
@@ -54,7 +54,9 @@ export function commentToAssert(code, { filename, typescript = false } = {}) {
           `assert.deepEqual(await ${exprSource}, ${expected});`,
         );
       } else if (isConsoleCall(node.expression)) {
-        // console.log(expr) //=> value → keep log, add assertion after
+        // console.log(expr) //=> value → keep log, add assertion after.
+        // Stay on the same line so subsequent markdown line numbers are
+        // preserved for error reporting.
         const arg = code.slice(
           node.expression.arguments[0].start,
           node.expression.arguments[0].end,
@@ -62,7 +64,7 @@ export function commentToAssert(code, { filename, typescript = false } = {}) {
         s.overwrite(
           node.expression.end,
           comment.end,
-          `;\nassert.deepEqual(${arg}, ${rest});`,
+          `; assert.deepEqual(${arg}, ${rest});`,
         );
       } else {
         // expr //=> value → assert.deepEqual(expr, value)

--- a/test/comment-to-assert.test.js
+++ b/test/comment-to-assert.test.js
@@ -34,6 +34,20 @@ describe("commentToAssert", () => {
     assert.ok(code.includes("assert.deepEqual(a, { a: 1 });"));
   });
 
+  it("console.log transform preserves line count", () => {
+    // Regression: the console.log transform used to insert "\n" between
+    // the call and its generated assertion, shifting every subsequent
+    // line and corrupting error line numbers.
+    const input = "console.log(a) //=> 1\nlet b = 2;\nb; //=> 2";
+    const { code } = commentToAssert(input);
+    const lines = code.split("\n");
+    assert.equal(lines.length, 3);
+    assert.ok(lines[0].includes("console.log(a)"));
+    assert.ok(lines[0].includes("assert.deepEqual(a, 1);"));
+    assert.equal(lines[1], "let b = 2;");
+    assert.ok(lines[2].includes("assert.deepEqual(b, 2);"));
+  });
+
   it("handles object expected values", () => {
     const { code } = commentToAssert("x //=> { a: 1, b: 2 }");
     assert.equal(code, "assert.deepEqual(x, { a: 1, b: 2 });");

--- a/test/fixtures/console-shift.md
+++ b/test/fixtures/console-shift.md
@@ -1,0 +1,7 @@
+# Console shift
+
+```javascript test
+console.log({ a: 1 }); //=> { a: 1 }
+let b = 2;
+b; //=> 3
+```

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -50,6 +50,15 @@ describe("run", () => {
     );
     assert.equal(result.exitCode, 0, result.stderr);
   });
+
+  it("reports the correct line when a block contains a console.log assertion", async () => {
+    // The failing expression `b; //=> 3` is on line 6 of console-shift.md.
+    // Regression: the console.log transform used to insert a newline which
+    // shifted later lines, pointing the error at the closing fence.
+    const result = await run(path.join(fixturesDir, "console-shift.md"));
+    assert.notEqual(result.exitCode, 0);
+    assert.match(result.stderr, /console-shift\.md:6/);
+  });
 });
 
 describe("resolveMainEntry", () => {


### PR DESCRIPTION
## Summary

- Replace the `;\n` separator in the `console.log(...) //=> v` transform with `; ` so the rewritten assertion stays on the same line as the original call.
- Everywhere else, `commentToAssert` carefully preserves column and line positions via in-place `magic-string.overwrite`. The console-log branch was the only spot that inserted a newline, which shifted every subsequent statement by one line and mis-aligned stack-trace line numbers with the markdown.

## Why

`run.js`'s `formatError` reads the failing line number from Node's stack trace and uses it to display a source snippet from the markdown. Before this fix, a block like

```markdown
\`\`\`javascript test
console.log({ a: 1 }); //=> { a: 1 }
let b = 2;
b; //=> 3
\`\`\`
```

failed with:

```
  FAIL  test/fixtures/console-shift.md:7

      5 | let b = 2;
      6 | b; //=> 3
 >    7 | \`\`\`
```

The `>` cursor pointed at the closing fence instead of at the failing assertion on line 6. After the fix the error reports line 6 correctly.

## Test plan

- [x] New unit test `console.log transform preserves line count` in `test/comment-to-assert.test.js` asserts the transformed code still has 3 lines for a 3-line input.
- [x] New integration test + fixture `test/fixtures/console-shift.md` runs a block whose failure falls *after* a `console.log` assertion and checks the stderr contains `console-shift.md:6`.
- [x] Verified both tests fail without the src change and pass with it (stashed-src sanity check).
- [x] `node --test test/*.test.js` — 46/46 pass.
- [x] `pnpm -r test` — all 10 workspace example packages still pass.