### PR TITLE
Detect ascii arrow and rejects in --auto mode

### DIFF
--- a/docs/code-blocks.md
+++ b/docs/code-blocks.md
@@ -43,8 +43,8 @@ Blocks without a group name each run independently.
 
 ## Auto-Discover Mode
 
-With `--auto`, any code block containing `//=>`, `// →`, or `// throws`
-is treated as a test — no `test` tag needed:
+With `--auto`, any code block containing `//=>`, `// →`, `// ->`,
+`// throws`, or `// rejects` is treated as a test — no `test` tag needed:
 
 ```
 readme-assert --auto

--- a/readme.md
+++ b/readme.md
@@ -120,8 +120,8 @@ x; //=> 2
 
 ### Auto-discover mode
 
-With `--auto`, any code block containing `//=>`, `// →`, or `// throws`
-is treated as a test — no `test` tag needed.
+With `--auto`, any code block containing `//=>`, `// →`, `// ->`,
+`// throws`, or `// rejects` is treated as a test — no `test` tag needed.
 
 ### All mode
 

--- a/src/extract.js
+++ b/src/extract.js
@@ -17,7 +17,7 @@ export function extractBlocks(markdown, { auto = false, all = false } = {}) {
   const fenceRe = /^(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))/gm;
   const supportedLangs = new Set(["javascript", "js", "typescript", "ts"]);
   const tsLangs = new Set(["typescript", "ts"]);
-  const assertRe = /\/[/*]\s*(=>|→|throws)/;
+  const assertRe = /\/[/*]\s*(=>|→|->|throws|rejects)/;
 
   let hasTypescript = false;
   const blocks = [];

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -77,10 +77,32 @@ describe("extractBlocks", () => {
     assert.equal(blocks.length, 1);
   });
 
+  it("auto mode detects ascii arrow", () => {
+    const md = [
+      "```javascript",
+      "1 + 1 // -> 2",
+      "```",
+    ].join("\n");
+
+    const { blocks } = extractBlocks(md, { auto: true });
+    assert.equal(blocks.length, 1);
+  });
+
   it("auto mode detects throws", () => {
     const md = [
       "```javascript",
       "fn() // throws /err/",
+      "```",
+    ].join("\n");
+
+    const { blocks } = extractBlocks(md, { auto: true });
+    assert.equal(blocks.length, 1);
+  });
+
+  it("auto mode detects rejects", () => {
+    const md = [
+      "```javascript",
+      "fn() // rejects /err/",
       "```",
     ].join("\n");
 


### PR DESCRIPTION
## Summary

- Extend the auto-detect regex in `src/extract.js` from `(=>|→|throws)` to `(=>|→|->|throws|rejects)` so it recognises the same assertion styles the parser already understands.
- Sync the README and `docs/code-blocks.md` "Auto-Discover Mode" sections to list all five markers.

## Why

`commentToAssert` accepts four `=>`-style markers (`=>`, `→`, `->`) plus `throws` and `rejects`, but `extract.js`'s `assertRe` only looked for three of them. In `--auto` mode a block like

```markdown
\`\`\`javascript
Promise.reject(new Error("no")) // rejects /no/
\`\`\`
```

was ignored entirely ("README has no test code blocks") even though `commentToAssert` would happily transform it. The same applied to the ASCII arrow `// -> value`. This is relevant for the `sindresorhus-compat` workflow, which runs real-world READMEs through `--auto` — any README using `->` or `rejects` silently got skipped.

## Test plan

- [x] Two new unit tests in `test/extract.test.js` mirror the existing `utf-8 arrow` and `throws` cases for the `-> ` and `rejects` markers.
- [x] Verified both new tests fail against the pre-fix `assertRe` (stashed-src sanity check).
- [x] `node --test test/*.test.js` — 46/46 pass (44 existing + 2 new).
- [x] `pnpm -r test` — all 10 workspace example packages still pass.