### PR TITLE
Print a clean error when no test blocks are found

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -68,20 +68,30 @@ const opts = {
   import: args.import,
 };
 
-if (args["print-code"]) {
-  const { processMarkdown } = await import("./run.js");
-  const units = await processMarkdown(filePath, opts);
-  for (const unit of units) {
-    console.log(`# --- ${unit.name} ---`);
-    console.log(unit.code);
+try {
+  if (args["print-code"]) {
+    const { processMarkdown } = await import("./run.js");
+    const units = await processMarkdown(filePath, opts);
+    for (const unit of units) {
+      console.log(`# --- ${unit.name} ---`);
+      console.log(unit.code);
+    }
+  } else {
+    const { run } = await import("./run.js");
+    const { exitCode, stdout, stderr, results } = await run(filePath, opts);
+    if (stdout) process.stdout.write(stdout);
+    if (stderr) process.stderr.write(stderr);
+    if (exitCode === 0) {
+      console.log(`All assertions passed. (${results.length} blocks)`);
+    }
+    process.exitCode = exitCode;
   }
-} else {
-  const { run } = await import("./run.js");
-  const { exitCode, stdout, stderr, results } = await run(filePath, opts);
-  if (stdout) process.stdout.write(stdout);
-  if (stderr) process.stderr.write(stderr);
-  if (exitCode === 0) {
-    console.log(`All assertions passed. (${results.length} blocks)`);
+} catch (err) {
+  if (err?.code === "NO_TEST_BLOCKS") {
+    const relPath = path.relative(process.cwd(), filePath);
+    console.error(`No test code blocks found in ${relPath}`);
+    process.exitCode = 1;
+  } else {
+    throw err;
   }
-  process.exitCode = exitCode;
 }

--- a/src/run.js
+++ b/src/run.js
@@ -39,7 +39,9 @@ export async function processMarkdown(filePath, options = {}) {
   });
 
   if (extracted.blocks.length === 0) {
-    throw new Error("README has no test code blocks");
+    const err = new Error(`No test code blocks found in ${filePath}`);
+    err.code = "NO_TEST_BLOCKS";
+    throw err;
   }
 
   const { units } = generate(extracted);

--- a/test/fixtures/no-blocks.md
+++ b/test/fixtures/no-blocks.md
@@ -1,0 +1,3 @@
+# No test blocks
+
+This readme has no test code blocks at all.

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { processMarkdown, resolveMainEntry, run } from "../src/run.js";
+
+const cliPath = new URL("../src/cli.js", import.meta.url).pathname;
 
 const fixturesDir = new URL("./fixtures/", import.meta.url).pathname;
 
@@ -30,6 +33,32 @@ describe("processMarkdown", () => {
       `expected import rewritten to ${expected}, got:\n${code}`,
     );
     assert.ok(!code.includes('"@fixture/string-exports"'));
+  });
+
+  it("throws NO_TEST_BLOCKS when the readme has no test blocks", async () => {
+    await assert.rejects(
+      () => processMarkdown(path.join(fixturesDir, "no-blocks.md")),
+      (err) => {
+        assert.equal(err.code, "NO_TEST_BLOCKS");
+        assert.match(err.message, /no-blocks\.md/);
+        return true;
+      },
+    );
+  });
+});
+
+describe("cli", () => {
+  it("exits cleanly when the readme has no test blocks", () => {
+    const result = spawnSync(
+      "node",
+      [cliPath, "-f", path.join(fixturesDir, "no-blocks.md")],
+      { encoding: "utf-8" },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /No test code blocks found/);
+    // Regression: no raw stack trace or node error banner should leak.
+    assert.doesNotMatch(result.stderr, /at processMarkdown/);
+    assert.doesNotMatch(result.stderr, /\bNode\.js v/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Tag the "no test blocks" error in `processMarkdown` with `err.code = "NO_TEST_BLOCKS"`.
- Wrap the CLI body in a `try/catch`: on `NO_TEST_BLOCKS`, print `No test code blocks found in <relative path>` to stderr and set `process.exitCode = 1`. Any other error is re-thrown so unexpected failures still surface with a stack trace.

## Why

`processMarkdown` used to `throw new Error("README has no test code blocks")` with nothing catching it. Because `src/cli.js` is a top-level-await ESM module, the error became an unhandled rejection and Node printed the full banner:

```
file:///.../src/run.js:42
    throw new Error("README has no test code blocks");
          ^
Error: README has no test code blocks
    at processMarkdown (file:///.../src/run.js:42:11)
    at run (file:///.../src/run.js:99:23)
    at file:///.../src/cli.js:80:55
Node.js v23.10.0
```

The `bails-when-no-tests-exists` workspace example "worked" only because its test script inverts the exit code with `readme-assert && exit 1 || exit 0`. After this PR the same example produces:

```
No test code blocks found in readme.md
```

with exit code 1, and nothing else.

## Test plan

- [x] New `processMarkdown` unit test asserts the thrown error has `code === "NO_TEST_BLOCKS"` and mentions the offending file.
- [x] New `cli` subprocess test spawns `src/cli.js` against `test/fixtures/no-blocks.md`, checks exit code 1, and asserts stderr contains the friendly message and *does not* contain `at processMarkdown` or a `Node.js v` banner — locking in the "no stack trace" guarantee.
- [x] Verified both tests fail against the pre-fix sources (stashed-src sanity check).
- [x] `node --test test/*.test.js` — 61/61 pass.
- [x] `pnpm -r test` — all 10 workspace example packages still pass; `bails-when-no-tests-exists` now prints `No test code blocks found in readme.md` instead of a Node stack trace.