### PR TITLE
Drop stale v7 branch from CI push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, main, v7]
+    branches: [master, main]
   pull_request:
     branches: [master, main]
 jobs:


### PR DESCRIPTION
## Summary

- Remove `v7` from the push trigger in `.github/workflows/ci.yml` so it matches `docs.yml` and the actual set of live branches.

## Why

Commit d2cbc47 ("Remove 'v7' branch from workflow triggers") removed `v7` from `docs.yml` but missed `ci.yml`, which still listed it in `on.push.branches: [master, main, v7]`. The remote has no `v7` branch (confirmed via `gh api repos/laat/readme-assert/branches`) — `master`, `next`, and `source-map` are the only long-lived refs — so the trigger is a no-op, and the inconsistency is confusing when reading the workflow.

## Test plan

- [x] `gh api repos/laat/readme-assert/branches --jq '.[].name'` — confirms no `v7` branch exists.
- [x] Both remaining entries (`master`, `main`) match the `pull_request` trigger below, so master pushes still run CI.