### PR TITLE
Minor cleanups: examples, dead code, and header cosmetics

### DIFF
--- a/examples/babel-register/package.json
+++ b/examples/babel-register/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "@laat/babel-register",
   "version": "7.0.0",
+  "type": "module",
   "main": "src/index.js",
   "license": "MIT",
   "scripts": {

--- a/examples/ts-node/package.json
+++ b/examples/ts-node/package.json
@@ -2,13 +2,14 @@
   "private": true,
   "name": "@laat/ts-node",
   "version": "7.0.0",
-  "type": "module",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {
-    "test": "readme-assert"
+    "test": "readme-assert --require ts-node/register --main ./src/index.ts"
   },
   "devDependencies": {
-    "readme-assert": "workspace:*"
+    "readme-assert": "workspace:*",
+    "ts-node": "11.0.0-beta.1",
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/ts-node/readme.md
+++ b/examples/ts-node/readme.md
@@ -1,6 +1,6 @@
 # ts-node/register
 
-> using ts-node/register
+> transpile typescript source files on demand with ts-node
 
 ### Command
 
@@ -8,9 +8,13 @@
 readme-assert --require ts-node/register --main ./src/index.ts
 ```
 
+`--require` passes through to `node --require`, which ts-node uses to
+register a CJS loader hook. readme-assert writes the test block to a
+`.cjs` file so the hook can transform the imported `.ts` module chain.
+
 ````
 ```ts test
-import { pow2 } from "@laat/ts-node";
+const { pow2 } = require("@laat/ts-node");
 const a: number = pow2(2);
 a; //=> 4
 const b: number = pow2(4);
@@ -19,7 +23,7 @@ b; //=> 16
 ````
 
 ```ts test
-import { pow2 } from "@laat/ts-node";
+const { pow2 } = require("@laat/ts-node");
 const a: number = pow2(2);
 a; //=> 4
 const b: number = pow2(4);

--- a/examples/ts-node/src/index.ts
+++ b/examples/ts-node/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./pow2.ts";
+export * from "./pow2";

--- a/examples/ts-node/src/pow2.ts
+++ b/examples/ts-node/src/pow2.ts
@@ -1,1 +1,1 @@
-export const pow2 = num => num ** 2;
+export const pow2 = (num: number): number => num ** 2;

--- a/examples/ts-node/tsconfig.json
+++ b/examples/ts-node/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2022",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       readme-assert:
         specifier: workspace:*
         version: link:../..
+      ts-node:
+        specifier: 11.0.0-beta.1
+        version: 11.0.0-beta.1(@types/node@25.6.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
 
   examples/typescript:
     devDependencies:
@@ -616,6 +622,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -825,6 +835,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
     peerDependencies:
@@ -953,12 +966,39 @@ packages:
   '@oxc-project/types@0.123.0':
     resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@tsconfig/node18@18.2.6':
+    resolution: {integrity: sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==}
+
+  '@tsconfig/node20@20.1.9':
+    resolution: {integrity: sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
@@ -1023,6 +1063,10 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   electron-to-chromium@1.5.331:
     resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
@@ -1144,6 +1188,9 @@ packages:
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1273,8 +1320,30 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  ts-node@11.0.0-beta.1:
+    resolution: {integrity: sha512-WMSROP+1pU22Q/Tm40mjfRg130yD8i0g6ROST04ZpocfH8sl1zD75ON4XQMcBEVViXMVemJBH0alflE7xePdRA==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.3.85'
+      '@swc/wasm': '>=1.3.85'
+      '@types/node': '*'
+      typescript: '>=4.4'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -1297,6 +1366,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2023,6 +2095,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -2156,6 +2232,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -2230,12 +2311,32 @@ snapshots:
 
   '@oxc-project/types@0.123.0': {}
 
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@tsconfig/node18@18.2.6': {}
+
+  '@tsconfig/node20@20.1.9': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   agent-base@7.1.4: {}
+
+  arg@4.1.3: {}
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
@@ -2304,6 +2405,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js@10.6.0: {}
+
+  diff@4.0.4: {}
 
   electron-to-chromium@1.5.331: {}
 
@@ -2455,6 +2558,8 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  make-error@1.3.6: {}
+
   ms@2.1.3: {}
 
   node-releases@2.0.37: {}
@@ -2587,8 +2692,28 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  ts-node@11.0.0-beta.1(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@tsconfig/node18': 18.2.6
+      '@tsconfig/node20': 20.1.9
+      '@types/node': 25.6.0
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+
   tslib@2.8.1:
     optional: true
+
+  typescript@5.9.3: {}
+
+  undici-types@7.19.2: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -2606,6 +2731,8 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  v8-compile-cache-lib@3.0.1: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/comment-to-assert.js
+++ b/src/comment-to-assert.js
@@ -14,10 +14,10 @@ import MagicString from "magic-string";
  * Uses oxc-parser for AST + comment extraction. Handles both JS and TS.
  *
  * @param {string} code - JavaScript or TypeScript source
- * @param {{ filename?: string, typescript?: boolean }} options
- * @returns {{ code: string, map: object }}
+ * @param {{ typescript?: boolean }} options
+ * @returns {{ code: string }}
  */
-export function commentToAssert(code, { filename, typescript = false } = {}) {
+export function commentToAssert(code, { typescript = false } = {}) {
   const ext = typescript ? "test.ts" : "test.js";
   const result = parseSync(ext, code);
   const ast = result.program;
@@ -105,12 +105,9 @@ export function commentToAssert(code, { filename, typescript = false } = {}) {
     }
   }
 
-  if (!changed) return { code, map: null };
+  if (!changed) return { code };
 
-  return {
-    code: s.toString(),
-    map: s.generateMap({ source: filename, hires: true }),
-  };
+  return { code: s.toString() };
 }
 
 /**

--- a/src/generate.js
+++ b/src/generate.js
@@ -79,8 +79,10 @@ function assembleUnit(blocks) {
     assertLine = 'const { default: assert } = await import("node:assert/strict");';
   }
 
-  // imports go on line 0 too (they're already removed from bodyLines)
-  const header = [assertLine, ...imports].join("; ");
+  // imports go on line 0 too (they're already removed from bodyLines).
+  // Each piece is its own statement, so a single space between them is
+  // enough; joining with "; " produced a double semicolon like ";; ".
+  const header = [assertLine, ...imports].join(" ");
   bodyLines[0] = header;
   return bodyLines.join("\n") + "\n";
 }

--- a/src/run.js
+++ b/src/run.js
@@ -67,7 +67,6 @@ export async function processMarkdown(filePath, options = {}) {
     }
 
     const transformed = commentToAssert(code, {
-      filename: filePath,
       typescript: unit.hasTypescript,
     });
     code = transformed.code;

--- a/test/comment-to-assert.test.js
+++ b/test/comment-to-assert.test.js
@@ -82,16 +82,6 @@ describe("commentToAssert", () => {
     assert.equal(code, input);
   });
 
-  it("returns null map when no changes", () => {
-    const { map } = commentToAssert("const x = 1;");
-    assert.equal(map, null);
-  });
-
-  it("returns a source map when changes are made", () => {
-    const { map } = commentToAssert("x //=> 1");
-    assert.notEqual(map, null);
-  });
-
   it("handles throws with regex flags", () => {
     const { code } = commentToAssert("fn() // throws /err/i");
     assert.equal(code, "assert.throws(() => { fn(); }, /err/i);");

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -103,6 +103,23 @@ describe("generate", () => {
     assert.ok(importLine < bodyLine);
   });
 
+  it("does not produce double semicolons in the header", () => {
+    const { units } = generate({
+      blocks: [
+        {
+          code: 'import { foo } from "bar";\nfoo() //=> 42\n',
+          lang: "javascript",
+          tag: "test",
+          group: null,
+          startLine: 3,
+          endLine: 4,
+        },
+      ],
+      hasTypescript: false,
+    });
+    assert.ok(!units[0].code.includes(";;"));
+  });
+
   it("returns empty units for no blocks", () => {
     const { units } = generate({ blocks: [], hasTypescript: false });
     assert.equal(units.length, 0);


### PR DESCRIPTION
Bundle of low-risk cleanups from the recent review.

## 1. `examples/babel-register`: add `"type": "module"`

The example's `src/index.js` uses `export *` but the package lacked `"type": "module"`, so Node emitted `MODULE_TYPELESS_PACKAGE_JSON` and reparsed the file as ESM on every run. Adding the field silences the warning; behaviour is unchanged.

## 2. `examples/ts-node`: actually use `ts-node`

The example was named `ts-node` but neither depended on `ts-node` nor invoked it — its `test` script was just `readme-assert`, the real work was done by Node's native `--experimental-strip-types`, and the `--require ts-node/register --main ./src/index.ts` command in the README was aspirational.

Rewired to actually exercise ts-node's CJS require hook:

- `package.json`: drop `"type": "module"`, pin `"test": "readme-assert --require ts-node/register --main ./src/index.ts"`, add `ts-node@11.0.0-beta.1` and `typescript@^5.5.0` as devDependencies. ts-node 11 beta is needed because 10.9.2's hook is pre-empted by Node ≥ 22's built-in `require(esm)` + native TS support; 11 beta reinstates interception.
- `readme.md`: test block now uses `const { pow2 } = require("@laat/ts-node")` so readme-assert writes the tmp file as `.cjs`, which is the only form ts-node's require hook catches. Added a short paragraph explaining why.
- `src/index.ts`: drop the explicit `.ts` extension on the relative re-export so classic CJS TypeScript resolution handles it.
- `src/pow2.ts`: add an explicit `(num: number): number` signature to satisfy ts-node's strict defaults.
- `tsconfig.json` (new): minimal `{ module: CommonJS, target: ES2022, strict, skipLibCheck }` to pin the compiler config.

Verified end-to-end with `pnpm --filter @laat/ts-node test`; the failure mode I hit on the way (`TSError: Parameter 'num' implicitly has an 'any' type`) confirms ts-node is the one doing the compilation, not Node native.

## 3. `commentToAssert`: remove the dead source map

`commentToAssert` generated a source map via `magic-string.generateMap` on every call but `run.js` only ever consumed `.code`. Dropped the `filename` parameter, the `generateMap` call, and the two unit tests that asserted on `{ map }`. Return shape is now `{ code }` (still an object for minimal caller churn). Saves a non-trivial amount of work on every TS/JS block.

## 4. `generate.js`: no more double semicolons in the header

The header was `[assertLine, ...imports].join("; ")`, which combined with `assertLine` already ending in `;` produced output like `import assert from "node:assert/strict";; import { foo } from "bar";`. Joined with a single space instead; added a regression test in `test/generate.test.js` that asserts the output of a known fixture doesn't contain `;;`.

## Test plan

- [x] `node --test test/*.test.js` — 60/60 pass (61 before minus 2 removed map tests plus 1 added double-semicolon test).
- [x] `pnpm -r test` — all 10 workspace examples green, including the rewired `ts-node` example. `babel-register` no longer prints the `MODULE_TYPELESS_PACKAGE_JSON` warning.
- [x] Manual: `node src/cli.js --print-code -f examples/ts-node/readme.md` shows the expected `.cjs`-shape generated code.