### PR TITLE
Tighten CLI arg parsing, simplify bails shim, add run.js coverage

### DIFF
--- a/examples/bails-when-no-tests-exists/package.json
+++ b/examples/bails-when-no-tests-exists/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.0",
   "license": "MIT",
   "scripts": {
-    "test": "readme-assert && exit 1 || exit 0"
+    "test": "! readme-assert"
   },
   "devDependencies": {
     "readme-assert": "workspace:*"

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,20 +3,28 @@ import { parseArgs } from "node:util";
 import path from "node:path";
 import fs from "node:fs";
 
-const { values: args } = parseArgs({
-  options: {
-    file: { type: "string", short: "f" },
-    main: { type: "string", short: "m" },
-    auto: { type: "boolean", short: "a", default: false },
-    all: { type: "boolean", short: "l", default: false },
-    require: { type: "string", short: "r", multiple: true },
-    import: { type: "string", short: "i", multiple: true },
-    "print-code": { type: "boolean", short: "p", default: false },
-    help: { type: "boolean", short: "h", default: false },
-    version: { type: "boolean", short: "v", default: false },
-  },
-  strict: false,
-});
+let args;
+try {
+  ({ values: args } = parseArgs({
+    options: {
+      file: { type: "string", short: "f" },
+      main: { type: "string", short: "m" },
+      auto: { type: "boolean", short: "a", default: false },
+      all: { type: "boolean", short: "l", default: false },
+      require: { type: "string", short: "r", multiple: true },
+      import: { type: "string", short: "i", multiple: true },
+      "print-code": { type: "boolean", short: "p", default: false },
+      help: { type: "boolean", short: "h", default: false },
+      version: { type: "boolean", short: "v", default: false },
+    },
+    strict: true,
+    allowPositionals: true,
+  }));
+} catch (err) {
+  console.error(err.message);
+  console.error("Run with --help to see supported options.");
+  process.exit(1);
+}
 
 if (args.help) {
   console.log(`

--- a/test/fixtures/require-downgrade/readme.md
+++ b/test/fixtures/require-downgrade/readme.md
@@ -1,0 +1,10 @@
+# Require downgrade fixture
+
+Plain code (no `import`/`export`/`require`) with a global set by a
+`--require`-loaded setup file. readme-assert should downgrade the
+generated dynamic-`import` assert line to `require()` so the `.cjs`
+tmp file actually goes through the `--require` hook.
+
+```javascript test
+myGlobal; //=> "hello from setup"
+```

--- a/test/fixtures/require-downgrade/setup.cjs
+++ b/test/fixtures/require-downgrade/setup.cjs
@@ -1,0 +1,1 @@
+global.myGlobal = "hello from setup";

--- a/test/fixtures/typescript.md
+++ b/test/fixtures/typescript.md
@@ -1,0 +1,8 @@
+# TypeScript fixture
+
+```typescript test
+const a: number = 1 + 1;
+const label: string = "two";
+a; //=> 2
+label; //=> "two"
+```

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -45,6 +45,18 @@ describe("processMarkdown", () => {
       },
     );
   });
+
+  it("strips TypeScript types via esbuild for ts blocks", async () => {
+    const units = await processMarkdown(path.join(fixturesDir, "typescript.md"));
+    assert.equal(units.length, 1);
+    const code = units[0].code;
+    // esbuild should have removed the TS type annotations
+    assert.ok(!code.includes(": number"), `expected no ": number" in:\n${code}`);
+    assert.ok(!code.includes(": string"), `expected no ": string" in:\n${code}`);
+    // The assert calls should still be there
+    assert.ok(code.includes("assert.deepEqual(a, 2);"));
+    assert.ok(code.includes('assert.deepEqual(label, "two");'));
+  });
 });
 
 describe("cli", () => {
@@ -59,6 +71,17 @@ describe("cli", () => {
     // Regression: no raw stack trace or node error banner should leak.
     assert.doesNotMatch(result.stderr, /at processMarkdown/);
     assert.doesNotMatch(result.stderr, /\bNode\.js v/);
+  });
+
+  it("rejects unknown flags with a friendly message", () => {
+    const result = spawnSync("node", [cliPath, "--autop"], {
+      encoding: "utf-8",
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /autop/);
+    assert.match(result.stderr, /--help/);
+    // No raw stack trace should leak from parseArgs
+    assert.doesNotMatch(result.stderr, /at parseArgs/);
   });
 });
 
@@ -87,6 +110,20 @@ describe("run", () => {
     const result = await run(path.join(fixturesDir, "console-shift.md"));
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /console-shift\.md:6/);
+  });
+
+  it("executes a TypeScript block end-to-end", async () => {
+    const result = await run(path.join(fixturesDir, "typescript.md"));
+    assert.equal(result.exitCode, 0, result.stderr);
+  });
+
+  it("downgrades plain blocks to CJS so --require hooks apply", async () => {
+    // Plain code (no import/export/require) + --require should produce a
+    // .cjs tmp file so the setup script's globals are visible to the block.
+    const readme = path.join(fixturesDir, "require-downgrade/readme.md");
+    const setup = path.join(fixturesDir, "require-downgrade/setup.cjs");
+    const result = await run(readme, { require: [setup] });
+    assert.equal(result.exitCode, 0, result.stderr);
   });
 });
 


### PR DESCRIPTION
Last of the follow-ups from the review — three independent fixes bundled into one PR because each is small.

## 1. Strict `parseArgs` in the CLI (#10)

Before: `parseArgs({ ..., strict: false })` silently accepted unknown flags, so `readme-assert --autop` succeeded and `--autop` was simply ignored. That's a foot-gun for typos.

After: `strict: true, allowPositionals: true`. Unknown flags throw from `parseArgs`; the throw is caught and turned into a two-line stderr message:

\`\`\`
Unknown option '--autop'. To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- "--autop"'
Run with --help to see supported options.
\`\`\`

`allowPositionals: true` keeps any accidental positional args permitted rather than bailing — positional args aren't currently meaningful but preserving them avoids surprise breakage.

## 2. Simplify `bails-when-no-tests-exists` shim (#6)

`test: readme-assert && exit 1 || exit 0` dates from when the "no test blocks" error printed a stack trace. PR #123 made the CLI exit cleanly with code 1 on `NO_TEST_BLOCKS`, so the shim reduces to `test: ! readme-assert`.

## 3. Extra `run.js` coverage (#13)

Three code paths were previously exercised only by the workspace examples:

- TypeScript block extraction → esbuild type stripping (covered only by `examples/typescript`).
- End-to-end TypeScript execution via `run()` (same).
- The `--require` CJS downgrade for plain code blocks (covered only by `examples/globals`).

Added direct unit/integration tests for each, with minimal fixtures:

- \`test/fixtures/typescript.md\` — a `typescript test` block with `: number` and `: string` annotations and two assertions; the \`processMarkdown\` test asserts the generated code has no type annotations and still contains the expected \`assert.deepEqual\` calls, and a \`run\` test asserts it executes to exit code 0.
- \`test/fixtures/require-downgrade/readme.md\` + \`setup.cjs\` — a plain JS block that references a \`myGlobal\` set by the CJS setup file; a \`run\` test passes \`--require\` and asserts exit code 0. This locks in the \"plain code + --require downgrades to .cjs so the hook applies\" behaviour.
- \`cli\` subprocess test for the new unknown-flag rejection (covers item #1 above).

## Test plan

- [x] \`node --test test/*.test.js\` — 64/64 pass (60 before + 4 new).
- [x] Verified the strict-args test fails against the pre-fix src/cli.js (stashed-src sanity check).
- [x] \`pnpm -r test\` — all 10 workspace examples still green; the simplified \`bails-when-no-tests-exists\` shim prints \"No test code blocks found in README.md\" and exits 0.