### PR TITLE
Stream child stdout live so long-running blocks don't look stalled

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -86,8 +86,9 @@ try {
     }
   } else {
     const { run } = await import("./run.js");
-    const { exitCode, stdout, stderr, results } = await run(filePath, opts);
-    if (stdout) process.stdout.write(stdout);
+    // stream: true pipes each child's stdout to process.stdout live so
+    // long-running blocks don't look stalled.
+    const { exitCode, stderr, results } = await run(filePath, { ...opts, stream: true });
     if (stderr) process.stderr.write(stderr);
     if (exitCode === 0) {
       console.log(`All assertions passed. (${results.length} blocks)`);

--- a/src/run.js
+++ b/src/run.js
@@ -92,8 +92,13 @@ export async function processMarkdown(filePath, options = {}) {
  * Each code block (or group) is written to a temp file and executed
  * sequentially. Stops on first failure.
  *
+ * When `options.stream` is true, each child's stdout chunk is written
+ * to `process.stdout` as it arrives so long-running blocks don't look
+ * stalled. Captured stdout is still returned in the result for
+ * programmatic callers.
+ *
  * @param {string} filePath
- * @param {{ auto?: boolean, all?: boolean, main?: string }} options
+ * @param {{ auto?: boolean, all?: boolean, main?: string, stream?: boolean }} options
  * @returns {Promise<{ exitCode: number, stdout: string, stderr: string, results: Array }>}
  */
 export async function run(filePath, options = {}) {
@@ -104,6 +109,7 @@ export async function run(filePath, options = {}) {
   const results = [];
 
   const useRequire = options.require?.length > 0;
+  const stream = options.stream ?? false;
 
   for (const unit of units) {
     let code = unit.code;
@@ -127,7 +133,7 @@ export async function run(filePath, options = {}) {
       for (const r of options.require || []) nodeArgs.push("--require", r);
       for (const i of options.import || []) nodeArgs.push("--import", i);
       nodeArgs.push(tmpFile);
-      const result = await exec("node", nodeArgs, dir, filePath);
+      const result = await exec("node", nodeArgs, dir, filePath, stream);
       allStdout += result.stdout;
       allStderr += result.stderr;
       results.push({ name: unit.name, ...result });
@@ -144,13 +150,16 @@ export async function run(filePath, options = {}) {
   return { exitCode: 0, stdout: allStdout, stderr: allStderr, results };
 }
 
-function exec(cmd, args, cwd, mdPath) {
+function exec(cmd, args, cwd, mdPath, stream) {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
 
-    child.stdout.on("data", (d) => (stdout += d));
+    child.stdout.on("data", (chunk) => {
+      if (stream) process.stdout.write(chunk);
+      stdout += chunk;
+    });
     child.stderr.on("data", (d) => (stderr += d));
 
     child.on("close", (exitCode) => {

--- a/test/fixtures/stream-delay.md
+++ b/test/fixtures/stream-delay.md
@@ -1,0 +1,11 @@
+# Stream delay fixture
+
+Prints a marker, then waits, then asserts. With `stream: true` the
+marker should appear in `process.stdout` well before the block's
+delay elapses.
+
+```javascript test
+console.log("STREAM-MARKER");
+await new Promise((r) => setTimeout(r, 500));
+1; //=> 1
+```

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { processMarkdown, resolveMainEntry, run } from "../src/run.js";
 
 const cliPath = new URL("../src/cli.js", import.meta.url).pathname;
@@ -82,6 +82,32 @@ describe("cli", () => {
     assert.match(result.stderr, /--help/);
     // No raw stack trace should leak from parseArgs
     assert.doesNotMatch(result.stderr, /at parseArgs/);
+  });
+
+  it("streams stdout live instead of buffering until the block finishes", async () => {
+    // stream-delay.md prints "STREAM-MARKER", sleeps 500ms, then asserts.
+    // With streaming, the marker should arrive well before the child exits.
+    const readme = path.join(fixturesDir, "stream-delay.md");
+    const child = spawn("node", [cliPath, "-f", readme]);
+    const start = Date.now();
+    let markerAt = null;
+    child.stdout.on("data", (chunk) => {
+      if (markerAt === null && chunk.toString().includes("STREAM-MARKER")) {
+        markerAt = Date.now() - start;
+      }
+    });
+    const exitCode = await new Promise((resolve) => {
+      child.on("exit", resolve);
+    });
+    const total = Date.now() - start;
+    assert.equal(exitCode, 0);
+    assert.ok(markerAt !== null, "STREAM-MARKER never appeared in stdout");
+    // The block sleeps 500ms after printing; if we're streaming, the
+    // marker should arrive at least 200ms before the child exits.
+    assert.ok(
+      markerAt < total - 200,
+      `marker arrived at ${markerAt}ms, total was ${total}ms — output looks buffered`,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `options.stream` to `run()`. When true, each child's `stdout` chunk is written to `process.stdout` as it arrives. Captured stdout is still accumulated into `result.stdout` for programmatic callers — streaming is additive, not destructive.
- `src/cli.js` passes `stream: true` and drops the final `process.stdout.write(stdout)` since it would just duplicate what's already been streamed. `stderr` is still captured silently and written at the end (unchanged) so `formatError` can produce its pretty summary without being interleaved with raw Node error output.

## Why

`run.js` used to buffer every child's stdout into a string, wait for the child to exit, return it, and only then let the CLI print it. Blocks that take a while — a network call, a long loop, or anything waiting on I/O — gave zero feedback until they finished. A user staring at a blank terminal has no way to tell the difference between "this is working" and "this is stuck."

The typical "progress" path is `console.log`, i.e. stdout. Streaming stderr too would mean raw Node error output followed by the formatted `FAIL` summary on every failure — extra noise in the common case — so stderr keeps the old buffered behaviour.

## Test plan

- [x] New fixture `test/fixtures/stream-delay.md` prints `STREAM-MARKER`, sleeps 500ms, then asserts `1 //=> 1`.
- [x] New test spawns the CLI via `child_process.spawn`, records when `STREAM-MARKER` first appears on stdout, then waits for exit. It asserts the marker arrived at least 200 ms before the child exited — i.e., the output is live, not buffered. The test takes ~577 ms locally (500 ms fixture sleep + overhead).
- [x] Verified the streaming test fails against the pre-fix sources (stashed-src sanity check) — without the change, the marker only appears after the child exits, so `markerAt < total - 200` is false.
- [x] `node --test test/*.test.js` — 65/65 pass (64 before + 1 new).
- [x] `pnpm -r test` — all 10 workspace examples still green.