### PR TITLE
Add /readme-test Claude Code skill and docs page

### DIFF
--- a/.claude/skills/readme-test.md
+++ b/.claude/skills/readme-test.md
@@ -1,0 +1,28 @@
+---
+name: readme-test
+description: Run readme-assert on the current project's README and diagnose or fix any failing test blocks. Invoke when the user wants to verify their README code examples still work, or mentions readme-assert, outdated README examples, broken code samples, or /readme-test.
+---
+
+# /readme-test
+
+You are helping the user verify their README's code blocks still work. The tool is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and runs them with assertion comments transformed into real assertions.
+
+## Steps
+
+1. **Find the README.** Look for `README.md` or `readme.md` in the current working directory. If neither exists, tell the user and stop.
+
+2. **Run it.** Execute `npx readme-assert` with Bash.
+
+3. **Interpret the result.**
+   - **Exit 0**: all good — report that N blocks passed and stop.
+   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no `test`-tagged blocks. Read the README, find the candidate fenced JavaScript / TypeScript blocks, and ask the user whether to (a) tag them explicitly by adding ` test` after the language fence, or (b) re-run with `--auto` so blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are picked up. Show the candidates.
+   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a source snippet and `expected: / received:` lines**: parse the failing line number, read that line in the README, understand what it's trying to demonstrate, and propose a targeted fix. When it's ambiguous whether the expected value or the code is wrong, ask before editing.
+   - **Exit 1, any other error**: print the error and ask the user for guidance.
+
+4. **After editing, re-run `npx readme-assert`** to confirm.
+
+## Tips
+
+- Keep fixes small. A stale `//=>` value usually just needs the expected value updated to match reality — check `git log` or the surrounding prose when unsure whether the expected or the code is canonical.
+- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert will execute for each block. Useful when a transform is doing something unexpected (e.g., a `console.log` assertion or a TypeScript block going through esbuild).
+- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`, `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at https://readme-assert.laat.dev/assertions/.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,3 +35,7 @@ That's it. If any assertion fails, the process exits with a non-zero code.
 3. Assertion comments (`//=> value`) are transformed into `assert.deepEqual()` calls
 4. Imports of your package name are rewritten to point to your local source
 5. Each block is written to a temp file and executed with `node`
+
+## Claude Code
+
+There's a [`/readme-test` skill](./skill.md) for [Claude Code](https://docs.claude.com/claude-code) that runs readme-assert and walks you through any failures.

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -1,0 +1,36 @@
+# Claude Code Skill
+
+Save this as `~/.claude/skills/readme-test.md` (or your project's
+`.claude/skills/readme-test.md`), then invoke with `/readme-test` in
+[Claude Code](https://docs.claude.com/claude-code).
+
+````markdown
+---
+name: readme-test
+description: Run readme-assert on the current project's README and diagnose or fix any failing test blocks. Invoke when the user wants to verify their README code examples still work, or mentions readme-assert, outdated README examples, broken code samples, or /readme-test.
+---
+
+# /readme-test
+
+You are helping the user verify their README's code blocks still work. The tool is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and runs them with assertion comments transformed into real assertions.
+
+## Steps
+
+1. **Find the README.** Look for `README.md` or `readme.md` in the current working directory. If neither exists, tell the user and stop.
+
+2. **Run it.** Execute `npx readme-assert` with Bash.
+
+3. **Interpret the result.**
+   - **Exit 0**: all good — report that N blocks passed and stop.
+   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no `test`-tagged blocks. Read the README, find the candidate fenced JavaScript / TypeScript blocks, and ask the user whether to (a) tag them explicitly by adding ` test` after the language fence, or (b) re-run with `--auto` so blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are picked up. Show the candidates.
+   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a source snippet and `expected: / received:` lines**: parse the failing line number, read that line in the README, understand what it's trying to demonstrate, and propose a targeted fix. When it's ambiguous whether the expected value or the code is wrong, ask before editing.
+   - **Exit 1, any other error**: print the error and ask the user for guidance.
+
+4. **After editing, re-run `npx readme-assert`** to confirm.
+
+## Tips
+
+- Keep fixes small. A stale `//=>` value usually just needs the expected value updated to match reality — check `git log` or the surrounding prose when unsure whether the expected or the code is canonical.
+- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert will execute for each block. Useful when a transform is doing something unexpected (e.g., a `console.log` assertion or a TypeScript block going through esbuild).
+- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`, `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at https://readme-assert.laat.dev/assertions/.
+````

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,8 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { processMarkdown, resolveMainEntry, run } from "../src/run.js";
+
+const repoRoot = new URL("../", import.meta.url).pathname;
 
 const cliPath = new URL("../src/cli.js", import.meta.url).pathname;
 
@@ -82,6 +85,31 @@ describe("cli", () => {
     assert.match(result.stderr, /--help/);
     // No raw stack trace should leak from parseArgs
     assert.doesNotMatch(result.stderr, /at parseArgs/);
+  });
+});
+
+describe("skill docs", () => {
+  it("keeps docs/skill.md in sync with .claude/skills/readme-test.md", () => {
+    const skill = fs.readFileSync(
+      path.join(repoRoot, ".claude/skills/readme-test.md"),
+      "utf-8",
+    );
+    const docs = fs.readFileSync(
+      path.join(repoRoot, "docs/skill.md"),
+      "utf-8",
+    );
+    // The docs page wraps the skill in a ```` markdown fence; extract it
+    // and verify byte-for-byte equality with the source-of-truth skill.
+    const match = docs.match(/^````markdown\n([\s\S]+?)\n````$/m);
+    assert.ok(
+      match,
+      "expected docs/skill.md to contain a ```` markdown fence",
+    );
+    assert.equal(
+      match[1],
+      skill.replace(/\n$/, ""),
+      "docs/skill.md code block is out of sync with .claude/skills/readme-test.md",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- New `.claude/skills/readme-test.md` — a Claude Code skill that runs \`npx readme-assert\` and walks the user through any failures. Invoked as \`/readme-test\`. Triggers on mentions of readme-assert, outdated README examples, or broken code samples.
- New \`docs/skill.md\` — a single docs page whose body is just a fenced \`markdown\` code block containing the full skill. Users copy-paste it into \`~/.claude/skills/readme-test.md\` (or their project's \`.claude/skills/\`).
- Linked from \`docs/index.md\` under a new "Claude Code" section.
- Drift guard: new \`skill docs\` test that extracts the fenced block from \`docs/skill.md\` and asserts byte-for-byte equality with the source skill, so the two can't quietly drift apart.

## What the skill does

1. Finds the README in the current working directory.
2. Runs \`npx readme-assert\`.
3. Interprets the exit code + stderr:
   - **0**: reports success briefly.
   - **\`No test code blocks found\`**: reads the README, finds candidate JS/TS blocks, and asks whether to tag them or re-run with \`--auto\`.
   - **\`FAIL path:line\` header**: parses the line number, reads that line in the README, and proposes a targeted fix.
4. Re-runs to confirm after any edit.

## What it doesn't do

- It doesn't install readme-assert — it relies on \`npx\` to fetch it on demand.
- It doesn't write new tests from scratch — users should point Claude at the [Code Blocks](./code-blocks.md) / [Assertions](./assertions.md) references for that.
- No plugin packaging; distribution is copy-paste for now.

## Test plan

- [x] \`node --test test/*.test.js\` — 65/65 pass (64 before + 1 new sync test).
- [x] Verified the sync test fails when the two files drift (manually appended a newline to the skill file, test failed as expected, reverted).
- [x] Rendered the docs/skill.md page in my head: the outer 4-backtick \`markdown\` fence correctly wraps the inner 3-backtick content (none of the inner fences use 4 backticks), so pymdownx.superfences should render it as a single code block.