### PR TITLE
Wrap the skill markdown at 80 columns

### DIFF
--- a/.claude/skills/readme-test.md
+++ b/.claude/skills/readme-test.md
@@ -1,28 +1,52 @@
 ---
 name: readme-test
-description: Run readme-assert on the current project's README and diagnose or fix any failing test blocks. Invoke when the user wants to verify their README code examples still work, or mentions readme-assert, outdated README examples, broken code samples, or /readme-test.
+description:
+  Run readme-assert on the current project's README and diagnose or fix any
+  failing test blocks. Invoke when the user wants to verify their README code
+  examples still work, or mentions readme-assert, outdated README examples,
+  broken code samples, or /readme-test.
 ---
 
 # /readme-test
 
-You are helping the user verify their README's code blocks still work. The tool is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and runs them with assertion comments transformed into real assertions.
+You are helping the user verify their README's code blocks still work. The tool
+is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code
+blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and
+runs them with assertion comments transformed into real assertions.
 
 ## Steps
 
-1. **Find the README.** Look for `README.md` or `readme.md` in the current working directory. If neither exists, tell the user and stop.
+1. **Find the README.** Look for `README.md` or `readme.md` in the current
+   working directory. If neither exists, tell the user and stop.
 
 2. **Run it.** Execute `npx readme-assert` with Bash.
 
 3. **Interpret the result.**
    - **Exit 0**: all good — report that N blocks passed and stop.
-   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no `test`-tagged blocks. Read the README, find the candidate fenced JavaScript / TypeScript blocks, and ask the user whether to (a) tag them explicitly by adding ` test` after the language fence, or (b) re-run with `--auto` so blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are picked up. Show the candidates.
-   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a source snippet and `expected: / received:` lines**: parse the failing line number, read that line in the README, understand what it's trying to demonstrate, and propose a targeted fix. When it's ambiguous whether the expected value or the code is wrong, ask before editing.
+   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no
+     `test`-tagged blocks. Read the README, find the candidate fenced JavaScript
+     / TypeScript blocks, and ask the user whether to (a) tag them explicitly by
+     adding ` test` after the language fence, or (b) re-run with `--auto` so
+     blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are
+     picked up. Show the candidates.
+   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a
+     source snippet and `expected: / received:` lines**: parse the failing line
+     number, read that line in the README, understand what it's trying to
+     demonstrate, and propose a targeted fix. When it's ambiguous whether the
+     expected value or the code is wrong, ask before editing.
    - **Exit 1, any other error**: print the error and ask the user for guidance.
 
 4. **After editing, re-run `npx readme-assert`** to confirm.
 
 ## Tips
 
-- Keep fixes small. A stale `//=>` value usually just needs the expected value updated to match reality — check `git log` or the surrounding prose when unsure whether the expected or the code is canonical.
-- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert will execute for each block. Useful when a transform is doing something unexpected (e.g., a `console.log` assertion or a TypeScript block going through esbuild).
-- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`, `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at https://readme-assert.laat.dev/assertions/.
+- Keep fixes small. A stale `//=>` value usually just needs the expected value
+  updated to match reality — check `git log` or the surrounding prose when
+  unsure whether the expected or the code is canonical.
+- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert
+  will execute for each block. Useful when a transform is doing something
+  unexpected (e.g., a `console.log` assertion or a TypeScript block going
+  through esbuild).
+- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`,
+  `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at
+  https://readme-assert.laat.dev/assertions/.

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -7,30 +7,54 @@ Save this as `~/.claude/skills/readme-test.md` (or your project's
 ````markdown
 ---
 name: readme-test
-description: Run readme-assert on the current project's README and diagnose or fix any failing test blocks. Invoke when the user wants to verify their README code examples still work, or mentions readme-assert, outdated README examples, broken code samples, or /readme-test.
+description:
+  Run readme-assert on the current project's README and diagnose or fix any
+  failing test blocks. Invoke when the user wants to verify their README code
+  examples still work, or mentions readme-assert, outdated README examples,
+  broken code samples, or /readme-test.
 ---
 
 # /readme-test
 
-You are helping the user verify their README's code blocks still work. The tool is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and runs them with assertion comments transformed into real assertions.
+You are helping the user verify their README's code blocks still work. The tool
+is [readme-assert](https://readme-assert.laat.dev/) — it extracts fenced code
+blocks tagged `test` (or any block containing `//=>` if `--auto` is used) and
+runs them with assertion comments transformed into real assertions.
 
 ## Steps
 
-1. **Find the README.** Look for `README.md` or `readme.md` in the current working directory. If neither exists, tell the user and stop.
+1. **Find the README.** Look for `README.md` or `readme.md` in the current
+   working directory. If neither exists, tell the user and stop.
 
 2. **Run it.** Execute `npx readme-assert` with Bash.
 
 3. **Interpret the result.**
    - **Exit 0**: all good — report that N blocks passed and stop.
-   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no `test`-tagged blocks. Read the README, find the candidate fenced JavaScript / TypeScript blocks, and ask the user whether to (a) tag them explicitly by adding ` test` after the language fence, or (b) re-run with `--auto` so blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are picked up. Show the candidates.
-   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a source snippet and `expected: / received:` lines**: parse the failing line number, read that line in the README, understand what it's trying to demonstrate, and propose a targeted fix. When it's ambiguous whether the expected value or the code is wrong, ask before editing.
+   - **Exit 1, stderr is `No test code blocks found in ...`**: the README has no
+     `test`-tagged blocks. Read the README, find the candidate fenced JavaScript
+     / TypeScript blocks, and ask the user whether to (a) tag them explicitly by
+     adding ` test` after the language fence, or (b) re-run with `--auto` so
+     blocks containing `//=>`, `// →`, `// ->`, `// throws`, or `// rejects` are
+     picked up. Show the candidates.
+   - **Exit 1, stderr contains a `FAIL <path>:<line>` header followed by a
+     source snippet and `expected: / received:` lines**: parse the failing line
+     number, read that line in the README, understand what it's trying to
+     demonstrate, and propose a targeted fix. When it's ambiguous whether the
+     expected value or the code is wrong, ask before editing.
    - **Exit 1, any other error**: print the error and ask the user for guidance.
 
 4. **After editing, re-run `npx readme-assert`** to confirm.
 
 ## Tips
 
-- Keep fixes small. A stale `//=>` value usually just needs the expected value updated to match reality — check `git log` or the surrounding prose when unsure whether the expected or the code is canonical.
-- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert will execute for each block. Useful when a transform is doing something unexpected (e.g., a `console.log` assertion or a TypeScript block going through esbuild).
-- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`, `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at https://readme-assert.laat.dev/assertions/.
+- Keep fixes small. A stale `//=>` value usually just needs the expected value
+  updated to match reality — check `git log` or the surrounding prose when
+  unsure whether the expected or the code is canonical.
+- `npx readme-assert --print-code -f <path>` prints the exact code readme-assert
+  will execute for each block. Useful when a transform is doing something
+  unexpected (e.g., a `console.log` assertion or a TypeScript block going
+  through esbuild).
+- Assertion syntax cheat sheet: `expr //=> value`, `expr // throws /regex/`,
+  `promise //=> resolves to value`, `promise // rejects /regex/`. Full docs at
+  https://readme-assert.laat.dev/assertions/.
 ````


### PR DESCRIPTION
## Summary

- Ran \`prettier@3 --prose-wrap always --print-width 80 --parser markdown\` on \`.claude/skills/readme-test.md\`.
- Updated \`docs/skill.md\` to match so the existing \`skill docs\` sync test still passes.

## Why

The docs-site code block doesn't soft-wrap, so the unwrapped paragraphs in the skill file overflow horizontally when rendered on https://readme-assert.laat.dev/skill/. Wrapping the source at 80 columns fixes the overflow.

Prettier converts the YAML \`description:\` from a single-line value to plain-scalar continuation (indent-aligned under the key), which is standard YAML and js-yaml-compatible. The longest remaining line is the one with the \`→\` character: 82 bytes in UTF-8 but 80 visible columns, which is fine for an 80-column terminal.

## Test plan

- [x] \`node --test test/integration.test.js\` — the \`skill docs\` sync test still passes (byte-for-byte match between \`.claude/skills/readme-test.md\` and the fenced block in \`docs/skill.md\`).
- [x] \`awk '{ if (length > 80) print NR }'\` — only line 30 exceeds 80 bytes, and only because \`→\` is multi-byte; \`wc -m\` confirms 80 characters.