### PR TITLE
Short-circuit doHoist AST walk once both flags are set

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -67,6 +67,7 @@ function doHoist(ast, code, resolve, requireMode) {
       if (n.type === "AwaitExpression") hasAwait = true;
       if (isRequireCall(n)) hasRequire = true;
     });
+    if (hasAwait && hasRequire) break;
   }
   const hasCJS = !hasAwait && !hasESM && hasRequire;
 


### PR DESCRIPTION
## Summary
- Break out of the `for...of` loop in `doHoist` once both `hasAwait` and `hasRequire` are true, avoiding unnecessary AST walks over remaining body nodes.

## Test plan
- All 109 existing tests pass with no changes.