### PR TITLE
Add source location to hoisted assert node

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -84,6 +84,8 @@ function doHoist(ast, code, resolve, requireMode) {
   }
 
   const assertNode = parseSync("t.js", assertCode).program.body[0];
+  const firstLoc = (declarations[0] || body[0]).loc;
+  stampLoc(assertNode, firstLoc);
   ast.body = [assertNode, ...declarations, ...body];
 
   return isESM;

--- a/src/transform.js
+++ b/src/transform.js
@@ -84,8 +84,8 @@ function doHoist(ast, code, resolve, requireMode) {
   }
 
   const assertNode = parseSync("t.js", assertCode).program.body[0];
-  const firstLoc = (declarations[0] || body[0]).loc;
-  stampLoc(assertNode, firstLoc);
+  const firstNode = declarations[0] || body[0];
+  if (firstNode) stampLoc(assertNode, firstNode.loc);
   ast.body = [assertNode, ...declarations, ...body];
 
   return isESM;


### PR DESCRIPTION
## Summary
- The `assertNode` in `doHoist` is parsed separately from the main AST, so `addLoc` never visits it. This leaves it without `loc` info, causing esrap to produce unmapped sourcemap entries for the assert import.
- Stamp `assertNode` with the location of the first original node (first declaration or first body statement) using `stampLoc`, so the hoisted assert import maps to the beginning of the block.

## Test plan
- All existing tests pass (`node --test`, 109/109).