### PR TITLE
Add JSDoc types, Prettier, and TypeScript checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install
+      - run: pnpm run format:check
+      - run: pnpm run typecheck
       - run: pnpm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -24,14 +24,18 @@ a; // -> 2
 Assert that an expression throws using `// throws` with a regex pattern:
 
 ```javascript
-const fail = () => { throw new Error("boom"); };
+const fail = () => {
+  throw new Error('boom');
+};
 fail(); // throws /boom/
 ```
 
 Or use `//=>` with an error name and optional message to match both:
 
 ```javascript
-const fail = () => { throw new TypeError("bad input"); };
+const fail = () => {
+  throw new TypeError('bad input');
+};
 fail(); //=> TypeError: bad input
 ```
 
@@ -52,7 +56,7 @@ When the expression uses `await`, the assertion is automatically promoted
 to `assert.rejects` with an async wrapper:
 
 ```javascript
-await fetch("/bad") //=> Error: not found
+await fetch('/bad'); //=> Error: not found
 ```
 
 ## Console Output
@@ -69,19 +73,19 @@ console.log(obj); //=> { a: 1 }
 Since `await` returns the resolved value, you can assert it directly:
 
 ```javascript
-await Promise.resolve(42) //=> 42
+await Promise.resolve(42); //=> 42
 ```
 
 Or use the explicit `resolves to` form without `await`:
 
 ```javascript
-Promise.resolve(42) //=> resolves to 42
+Promise.resolve(42); //=> resolves to 42
 ```
 
 The `to` is optional:
 
 ```javascript
-fetch("/api") //=> resolves { ok: true }
+fetch('/api'); //=> resolves { ok: true }
 ```
 
 This generates `assert.deepEqual(await expr, value)`.
@@ -91,7 +95,7 @@ This generates `assert.deepEqual(await expr, value)`.
 Assert that a Promise rejects matching a pattern:
 
 ```javascript
-fetch("/missing") // rejects /not found/
+fetch('/missing'); // rejects /not found/
 ```
 
 This generates `await assert.rejects(() => expr, /pattern/)`.
@@ -99,20 +103,20 @@ This generates `await assert.rejects(() => expr, /pattern/)`.
 Or match the error name and message with `//=> rejects`:
 
 ```javascript
-fetch("/missing") //=> rejects TypeError: not found
+fetch('/missing'); //=> rejects TypeError: not found
 ```
 
 The message can also be a regex:
 
 ```javascript
-fetch("/missing") //=> rejects TypeError: /not found/
+fetch('/missing'); //=> rejects TypeError: /not found/
 ```
 
 Await expressions work the same way — `// throws` and `// rejects` are
 both promoted to async rejects automatically:
 
 ```javascript
-await fetch("/missing") // throws /not found/
+await fetch('/missing'); // throws /not found/
 ```
 
 ## What Gets Generated
@@ -120,12 +124,12 @@ await fetch("/missing") // throws /not found/
 Given:
 
 ```javascript
-1 + 1 //=> 2
+1 + 1; //=> 2
 ```
 
 readme-assert generates:
 
 ```javascript
-const { default: assert } = await import("node:assert/strict");
+const { default: assert } = await import('node:assert/strict');
 assert.deepEqual(1 + 1, 2);
 ```

--- a/docs/code-blocks.md
+++ b/docs/code-blocks.md
@@ -6,11 +6,11 @@ Tag your fenced code blocks with `test` or `should` to mark them as tests:
 
 ````markdown
 ```javascript test
-1 + 1 //=> 2
+1 + 1; //=> 2
 ```
 
 ```javascript should add numbers
-1 + 1 //=> 2
+1 + 1; //=> 2
 ```
 ````
 

--- a/docs/import-renaming.md
+++ b/docs/import-renaming.md
@@ -21,13 +21,13 @@ Given a `package.json`:
 And a readme code block:
 
 ```javascript
-import { foo } from "my-package";
+import { foo } from 'my-package';
 ```
 
 The import is rewritten to:
 
 ```javascript
-import { foo } from "/absolute/path/to/index.js";
+import { foo } from '/absolute/path/to/index.js';
 ```
 
 ## Sub-path Imports
@@ -35,9 +35,9 @@ import { foo } from "/absolute/path/to/index.js";
 Sub-path imports are also rewritten:
 
 ```javascript
-import { helper } from "my-package/utils";
+import { helper } from 'my-package/utils';
 // becomes:
-import { helper } from "/absolute/path/to/utils";
+import { helper } from '/absolute/path/to/utils';
 ```
 
 ## CJS require()
@@ -45,9 +45,9 @@ import { helper } from "/absolute/path/to/utils";
 CommonJS `require()` calls are rewritten too:
 
 ```javascript
-const foo = require("my-package");
+const foo = require('my-package');
 // becomes:
-const foo = require("/absolute/path/to/index.js");
+const foo = require('/absolute/path/to/index.js');
 ```
 
 ## Overriding with --main

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Add test assertions to code blocks in your `README.md`:
 
 ````markdown
 ```javascript test
-1 + 1 //=> 2
+1 + 1; //=> 2
 ```
 ````
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -5,6 +5,7 @@ Save this as your agent's skill file (e.g.
 [Claude Code](https://docs.claude.com/claude-code)) and invoke with
 `/readme-assert`.
 
+<!-- prettier-ignore -->
 ````markdown
 ---
 name: readme-assert

--- a/examples/auto-discover-tests/index.js
+++ b/examples/auto-discover-tests/index.js
@@ -1,1 +1,1 @@
-module.exports = num => Math.pow(num, 2);
+module.exports = (num) => Math.pow(num, 2);

--- a/examples/auto-discover-tests/readme.md
+++ b/examples/auto-discover-tests/readme.md
@@ -31,7 +31,7 @@ pow2(4); //=> 16
 ````
 
 ```js
-const pow2 = require("@laat/auto");
+const pow2 = require('@laat/auto');
 pow2(2); //=> 4
 pow2(4); //=> 16
 ```

--- a/examples/babel-register/.babelrc
+++ b/examples/babel-register/.babelrc
@@ -1,5 +1,3 @@
 {
-  "presets": [
-    "@babel/preset-env"
-  ]
+  "presets": ["@babel/preset-env"]
 }

--- a/examples/babel-register/readme.md
+++ b/examples/babel-register/readme.md
@@ -17,7 +17,7 @@ pow2(4); //=> 16
 ````
 
 ```js test
-import { pow2 } from "@laat/babel-register";
+import { pow2 } from '@laat/babel-register';
 pow2(2); //=> 4
 pow2(4); //=> 16
 ```

--- a/examples/babel-register/src/index.js
+++ b/examples/babel-register/src/index.js
@@ -1,1 +1,1 @@
-export * from "./pow2.js";
+export * from './pow2.js';

--- a/examples/babel-register/src/pow2.js
+++ b/examples/babel-register/src/pow2.js
@@ -1,1 +1,1 @@
-export const pow2 = num => num ** 2;
+export const pow2 = (num) => num ** 2;

--- a/examples/esm/index.js
+++ b/examples/esm/index.js
@@ -1,1 +1,1 @@
-module.exports = num => Math.pow(num, 2);
+module.exports = (num) => Math.pow(num, 2);

--- a/examples/esm/readme.md
+++ b/examples/esm/readme.md
@@ -17,7 +17,7 @@ pow2(4); //=> 16
 ````
 
 ```js test
-import pow2 from "@laat/esm";
+import pow2 from '@laat/esm';
 pow2(2); //=> 4
 pow2(4); //=> 16
 ```

--- a/examples/globals/test-setup.js
+++ b/examples/globals/test-setup.js
@@ -1,1 +1,1 @@
-global.myGlobal = "hello global";
+global.myGlobal = 'hello global';

--- a/examples/jsdom/readme.md
+++ b/examples/jsdom/readme.md
@@ -14,6 +14,6 @@ document.body.innerHTML; // => 'hello'
 ````
 
 ```js test
-document.body.innerHTML = "hello";
+document.body.innerHTML = 'hello';
 document.body.innerHTML; // => 'hello'
 ```

--- a/examples/ts-node/readme.md
+++ b/examples/ts-node/readme.md
@@ -23,7 +23,7 @@ b; //=> 16
 ````
 
 ```ts test
-const { pow2 } = require("@laat/ts-node");
+const { pow2 } = require('@laat/ts-node');
 const a: number = pow2(2);
 a; //=> 4
 const b: number = pow2(4);

--- a/examples/ts-node/src/index.ts
+++ b/examples/ts-node/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./pow2";
+export * from './pow2';

--- a/examples/typescript/index.js
+++ b/examples/typescript/index.js
@@ -1,1 +1,1 @@
-module.exports = num => Math.pow(num, 2);
+module.exports = (num) => Math.pow(num, 2);

--- a/examples/typescript/readme.md
+++ b/examples/typescript/readme.md
@@ -21,7 +21,7 @@ b; //=> 16
 ````
 
 ```ts test
-import pow2 from "@laat/typescript";
+import pow2 from '@laat/typescript';
 const a: number = pow2(2);
 a; //=> 4
 const b: number = pow2(4);

--- a/examples/vanilla/index.js
+++ b/examples/vanilla/index.js
@@ -1,1 +1,1 @@
-module.exports = num => Math.pow(num, 2);
+module.exports = (num) => Math.pow(num, 2);

--- a/examples/vanilla/readme.md
+++ b/examples/vanilla/readme.md
@@ -15,7 +15,7 @@ pow2(4); //=> 16
 ````
 
 ```js test
-const pow2 = require("@laat/vanilla");
+const pow2 = require('@laat/vanilla');
 pow2(2); //=> 4
 pow2(4); //=> 16
 ```

--- a/package.json
+++ b/package.json
@@ -41,11 +41,19 @@
     "oxc-parser": "^0.123.0"
   },
   "scripts": {
-    "test": "node --test test/*.test.js && pnpm -r test"
+    "test": "node --test test/*.test.js && pnpm -r test",
+    "typecheck": "tsc",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
     ]
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "prettier": "^3.8.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,16 @@ importers:
       oxc-parser:
         specifier: ^0.123.0
         version: 0.123.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      prettier:
+        specifier: ^3.8.2
+        version: 3.8.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   examples/auto-discover-tests:
     devDependencies:
@@ -1246,6 +1256,11 @@ packages:
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
     engines: {node: '>=6'}
+
+  prettier@3.8.2:
+    resolution: {integrity: sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2626,6 +2641,8 @@ snapshots:
   pkg-dir@3.0.0:
     dependencies:
       find-up: 3.0.0
+
+  prettier@3.8.2: {}
 
   punycode@2.3.1: {}
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Assert that an expression throws using `// throws` with a regex pattern:
 
 ```javascript test
 const b = () => {
-  throw new Error("fail");
+  throw new Error('fail');
 };
 b(); // throws /fail/
 ```
@@ -75,7 +75,7 @@ Or use `//=>` with an error name and optional message to match both:
 
 ```javascript test
 const c = () => {
-  throw new TypeError("bad input");
+  throw new TypeError('bad input');
 };
 c(); //=> TypeError: bad input
 ```
@@ -84,8 +84,8 @@ Await expressions work too — they are automatically promoted to async
 rejects:
 
 ```javascript test
-const d = () => Promise.reject(new Error("boom"));
-await d() //=> Error: boom
+const d = () => Promise.reject(new Error('boom'));
+await d(); //=> Error: boom
 ```
 
 ### console.log
@@ -102,25 +102,25 @@ console.log(a); //=> { a: 1 }
 Since `await` returns the resolved value, you can assert it directly:
 
 ```javascript test
-await Promise.resolve(true) //=> true
+await Promise.resolve(true); //=> true
 ```
 
 Or use the explicit `resolves to` form without `await`:
 
 ```javascript test
-Promise.resolve(true) //=> resolves to true
+Promise.resolve(true); //=> resolves to true
 ```
 
 Assert that a promise rejects with `// rejects`:
 
 ```javascript test
-Promise.reject(new Error("no")) // rejects /no/
+Promise.reject(new Error('no')); // rejects /no/
 ```
 
 Or match the error name and message with `//=> rejects`:
 
 ```javascript test
-Promise.reject(new TypeError("no")) //=> rejects TypeError: no
+Promise.reject(new TypeError('no')); //=> rejects TypeError: no
 ```
 
 ### TypeScript

--- a/src/ast.js
+++ b/src/ast.js
@@ -1,9 +1,24 @@
-import { visitorKeys } from "oxc-parser";
+import { visitorKeys } from 'oxc-parser';
+
+/**
+ * @import { Comment, Program } from "oxc-parser"
+ * @import { Node, Statement, Expression, StringLiteral, ExpressionStatement } from "@oxc-project/types"
+ */
+
+/**
+ * @typedef {{ line: number, column: number }} Position
+ * @typedef {{ start: Position, end: Position }} SourceLocation
+ * @typedef {Record<string, any> & { type: string, start?: number, end?: number, loc?: SourceLocation }} AstNode
+ */
 
 export const assertCommentRe = /\/\/\s*(=>|→|->|throws|rejects)/;
 
+/**
+ * @param {AstNode} node
+ * @param {(node: AstNode) => void} visitor
+ */
 export function walkAst(node, visitor) {
-  if (!node || typeof node !== "object") return;
+  if (!node || typeof node !== 'object') return;
   if (node.type) {
     visitor(node);
     const keys = visitorKeys[node.type];
@@ -28,54 +43,84 @@ export function walkAst(node, visitor) {
   }
 }
 
+/**
+ * @param {AstNode} node
+ * @returns {boolean}
+ */
 export function isDeclaration(node) {
   return (
-    node.type === "ImportDeclaration" ||
-    node.type === "ExportNamedDeclaration" ||
-    node.type === "ExportDefaultDeclaration" ||
-    node.type === "ExportAllDeclaration"
+    node.type === 'ImportDeclaration' ||
+    node.type === 'ExportNamedDeclaration' ||
+    node.type === 'ExportDefaultDeclaration' ||
+    node.type === 'ExportAllDeclaration'
   );
 }
 
+/**
+ * @param {AstNode} node
+ * @returns {AstNode | null}
+ */
 export function getSourceNode(node) {
-  if (node.type === "ImportDeclaration") return node.source;
-  if (node.type === "ExportNamedDeclaration" && node.source) return node.source;
-  if (node.type === "ExportAllDeclaration") return node.source;
+  if (node.type === 'ImportDeclaration') return node.source;
+  if (node.type === 'ExportNamedDeclaration' && node.source) return node.source;
+  if (node.type === 'ExportAllDeclaration') return node.source;
   return null;
 }
 
+/**
+ * @param {AstNode} node
+ * @returns {boolean}
+ */
 export function isRequireCall(node) {
   return (
-    node.type === "CallExpression" &&
-    node.callee?.type === "Identifier" &&
-    node.callee.name === "require" &&
+    node.type === 'CallExpression' &&
+    node.callee?.type === 'Identifier' &&
+    node.callee.name === 'require' &&
     node.arguments?.length >= 1 &&
-    (node.arguments[0].type === "StringLiteral" || node.arguments[0].type === "Literal") &&
-    typeof node.arguments[0].value === "string"
+    (node.arguments[0].type === 'StringLiteral' ||
+      node.arguments[0].type === 'Literal') &&
+    typeof node.arguments[0].value === 'string'
   );
 }
 
+/**
+ * @param {AstNode} node
+ * @returns {AstNode[]}
+ */
 export function findRequireCalls(node) {
+  /** @type {AstNode[]} */
   const results = [];
-  walkAst(node, (n) => { if (isRequireCall(n)) results.push(n); });
+  walkAst(node, (n) => {
+    if (isRequireCall(n)) results.push(n);
+  });
   return results;
 }
 
+/**
+ * @param {AstNode} expr
+ * @returns {boolean}
+ */
 export function isConsoleCall(expr) {
   return (
-    expr.type === "CallExpression" &&
-    expr.callee?.type === "MemberExpression" &&
-    expr.callee.object?.type === "Identifier" &&
-    expr.callee.object.name === "console"
+    expr.type === 'CallExpression' &&
+    expr.callee?.type === 'MemberExpression' &&
+    expr.callee.object?.type === 'Identifier' &&
+    expr.callee.object.name === 'console'
   );
 }
 
+/**
+ * @param {Comment[]} comments
+ * @param {AstNode} node
+ * @param {string} code
+ * @returns {Comment | null}
+ */
 export function findTrailingComment(comments, node, code) {
   for (const c of comments) {
-    if (c.type !== "Line") continue;
+    if (c.type !== 'Line') continue;
     if (c.start < node.expression.end) continue;
     const between = code.slice(node.expression.end, c.start);
-    if (between.includes("\n")) continue;
+    if (between.includes('\n')) continue;
     return c;
   }
   return null;
@@ -83,16 +128,26 @@ export function findTrailingComment(comments, node, code) {
 
 // --- Location utilities ---
 
+/**
+ * @param {string} source
+ * @returns {number[]}
+ */
 export function buildLineIndex(source) {
   const starts = [0];
   for (let i = 0; i < source.length; i++) {
-    if (source[i] === "\n") starts.push(i + 1);
+    if (source[i] === '\n') starts.push(i + 1);
   }
   return starts;
 }
 
+/**
+ * @param {number[]} lineStarts
+ * @param {number} offset
+ * @returns {Position}
+ */
 export function offsetToLoc(lineStarts, offset) {
-  let lo = 0, hi = lineStarts.length - 1;
+  let lo = 0,
+    hi = lineStarts.length - 1;
   while (lo < hi) {
     const mid = (lo + hi + 1) >> 1;
     if (lineStarts[mid] <= offset) lo = mid;
@@ -101,18 +156,28 @@ export function offsetToLoc(lineStarts, offset) {
   return { line: lo + 1, column: offset - lineStarts[lo] };
 }
 
+/**
+ * @param {AstNode} ast
+ * @param {string} source
+ */
 export function addLoc(ast, source) {
   const lineStarts = buildLineIndex(source);
   walkAst(ast, (node) => {
-    if ("start" in node && "end" in node) {
+    if ('start' in node && 'end' in node) {
       node.loc = {
-        start: offsetToLoc(lineStarts, node.start),
-        end: offsetToLoc(lineStarts, node.end),
+        start: offsetToLoc(lineStarts, /** @type {number} */ (node.start)),
+        end: offsetToLoc(lineStarts, /** @type {number} */ (node.end)),
       };
     }
   });
 }
 
+/**
+ * @param {AstNode} node
+ * @param {SourceLocation} loc
+ */
 export function stampLoc(node, loc) {
-  walkAst(node, (n) => { n.loc = loc; });
+  walkAst(node, (n) => {
+    n.loc = loc;
+  });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,28 +1,28 @@
 #!/usr/bin/env node
-import { parseArgs } from "node:util";
-import path from "node:path";
-import fs from "node:fs";
+import { parseArgs } from 'node:util';
+import path from 'node:path';
+import fs from 'node:fs';
 
 let args;
 try {
   ({ values: args } = parseArgs({
     options: {
-      file: { type: "string", short: "f" },
-      main: { type: "string", short: "m" },
-      auto: { type: "boolean", short: "a", default: false },
-      all: { type: "boolean", short: "l", default: false },
-      require: { type: "string", short: "r", multiple: true },
-      import: { type: "string", short: "i", multiple: true },
-      "print-code": { type: "boolean", short: "p", default: false },
-      help: { type: "boolean", short: "h", default: false },
-      version: { type: "boolean", short: "v", default: false },
+      file: { type: 'string', short: 'f' },
+      main: { type: 'string', short: 'm' },
+      auto: { type: 'boolean', short: 'a', default: false },
+      all: { type: 'boolean', short: 'l', default: false },
+      require: { type: 'string', short: 'r', multiple: true },
+      import: { type: 'string', short: 'i', multiple: true },
+      'print-code': { type: 'boolean', short: 'p', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+      version: { type: 'boolean', short: 'v', default: false },
     },
     strict: true,
     allowPositionals: true,
   }));
-} catch (err) {
+} catch (/** @type {any} */ err) {
   console.error(err.message);
-  console.error("Run with --help to see supported options.");
+  console.error('Run with --help to see supported options.');
   process.exit(1);
 }
 
@@ -47,14 +47,14 @@ Options:
 }
 
 if (args.version) {
-  const pkgPath = new URL("../package.json", import.meta.url);
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+  const pkgPath = new URL('../package.json', import.meta.url);
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
   console.log(pkg.version);
   process.exit(0);
 }
 
 function findReadme() {
-  for (const name of ["README.md", "readme.md"]) {
+  for (const name of ['README.md', 'readme.md']) {
     const p = path.resolve(name);
     if (fs.existsSync(p)) return p;
   }
@@ -64,7 +64,7 @@ function findReadme() {
 const filePath = args.file ? path.resolve(args.file) : findReadme();
 
 if (!filePath) {
-  console.error("Could not locate readme.md");
+  console.error('Could not locate readme.md');
   process.exit(1);
 }
 
@@ -77,26 +77,29 @@ const opts = {
 };
 
 try {
-  if (args["print-code"]) {
-    const { processMarkdown } = await import("./run.js");
+  if (args['print-code']) {
+    const { processMarkdown } = await import('./run.js');
     const units = await processMarkdown(filePath, opts);
     for (const unit of units) {
       console.log(`# --- ${unit.name} ---`);
       console.log(unit.code);
     }
   } else {
-    const { run } = await import("./run.js");
+    const { run } = await import('./run.js');
     // stream: true pipes each child's stdout to process.stdout live so
     // long-running blocks don't look stalled.
-    const { exitCode, stderr, results } = await run(filePath, { ...opts, stream: true });
+    const { exitCode, stderr, results } = await run(filePath, {
+      ...opts,
+      stream: true,
+    });
     if (stderr) process.stderr.write(stderr);
     if (exitCode === 0) {
       console.log(`All assertions passed. (${results.length} blocks)`);
     }
     process.exitCode = exitCode;
   }
-} catch (err) {
-  if (err?.code === "NO_TEST_BLOCKS") {
+} catch (/** @type {any} */ err) {
+  if (err?.code === 'NO_TEST_BLOCKS') {
     const relPath = path.relative(process.cwd(), filePath);
     console.error(`No test code blocks found in ${relPath}`);
     process.exitCode = 1;

--- a/src/extract.js
+++ b/src/extract.js
@@ -1,37 +1,47 @@
-import { assertCommentRe } from "./ast.js";
+import { assertCommentRe } from './ast.js';
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   lang: string,
+ *   tag: string,
+ *   group: string | null,
+ *   startLine: number,
+ *   endLine: number,
+ * }} Block
+ */
 
 /**
  * Extract tagged code blocks from a markdown string.
  *
- * @param {string} markdown
- * @param {{ auto?: boolean, all?: boolean }} options
- * @returns {{ blocks: Block[], hasTypescript: boolean }}
- *
- * Block: { code, lang, tag, group, startLine, endLine }
- *
  * Tags: "test", "test:groupname", "should description", "should:groupname description"
  * Blocks with the same group name are merged into a single execution unit.
  * Blocks without a group name each run independently.
+ *
+ * @param {string} markdown
+ * @param {{ auto?: boolean, all?: boolean }} [options]
+ * @returns {{ blocks: Block[], hasTypescript: boolean }}
  */
 export function extractBlocks(markdown, { auto = false, all = false } = {}) {
   // Based on gfm-code-block-regex — the backreference \2 ensures a 4-backtick
   // fence only closes with 4 backticks, so nested display fences are skipped.
   const fenceRe = /^(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))/gm;
-  const supportedLangs = new Set(["javascript", "js", "typescript", "ts"]);
-  const tsLangs = new Set(["typescript", "ts"]);
+  const supportedLangs = new Set(['javascript', 'js', 'typescript', 'ts']);
+  const tsLangs = new Set(['typescript', 'ts']);
   let hasTypescript = false;
+  /** @type {Block[]} */
   const blocks = [];
   let match;
 
   while ((match = fenceRe.exec(markdown)) !== null) {
     const infoString = match[3].trim();
-    const code = match[4].replace(/^\n/, "");
+    const code = match[4].replace(/^\n/, '');
     const blockStart = match.index;
 
     // Parse language and tag from info string (e.g. "javascript test" or "ts test:group")
     const parts = infoString.split(/\s+/);
-    const lang = parts[0] || "";
-    const tag = parts.slice(1).join(" ");
+    const lang = parts[0] || '';
+    const tag = parts.slice(1).join(' ');
 
     if (!supportedLangs.has(lang)) continue;
 
@@ -40,23 +50,23 @@ export function extractBlocks(markdown, { auto = false, all = false } = {}) {
       if (auto) {
         if (!assertCommentRe.test(code)) continue;
       } else {
-        const firstWord = tag.split(/\s+/)[0] || "";
-        const keyword = firstWord.split(":")[0];
-        if (keyword !== "test" && keyword !== "should") continue;
+        const firstWord = tag.split(/\s+/)[0] || '';
+        const keyword = firstWord.split(':')[0];
+        if (keyword !== 'test' && keyword !== 'should') continue;
       }
     }
 
     // Count lines before this block to get startLine (1-based)
-    const linesBeforeBlock = markdown.slice(0, blockStart).split("\n").length;
+    const linesBeforeBlock = markdown.slice(0, blockStart).split('\n').length;
     const startLine = linesBeforeBlock + 1; // +1 for the fence line itself
-    const codeLines = code.split("\n").length;
+    const codeLines = code.split('\n').length;
     const endLine = startLine + codeLines - 1;
 
     if (tsLangs.has(lang)) hasTypescript = true;
 
     // Parse group from tag: "test:mygroup ..." or "should:mygroup ..."
-    const firstTagWord = tag.split(/\s+/)[0] || "";
-    const colonIdx = firstTagWord.indexOf(":");
+    const firstTagWord = tag.split(/\s+/)[0] || '';
+    const colonIdx = firstTagWord.indexOf(':');
     const group = colonIdx !== -1 ? firstTagWord.slice(colonIdx + 1) : null;
 
     blocks.push({ code, lang, tag, group, startLine, endLine });

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,19 +1,45 @@
+/**
+ * @import { Block } from "./extract.js"
+ */
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   name: string,
+ *   hasTypescript: boolean,
+ * }} Unit
+ */
+
+/**
+ * @param {{ blocks: Block[] }} extracted
+ * @returns {{ units: Unit[] }}
+ */
 export function generate({ blocks }) {
   if (blocks.length === 0) return { units: [] };
 
+  /** @type {Map<string, { blocks: Block[], name: string }>} */
   const groups = new Map();
+  /** @type {{ blocks: Block[], name: string }[]} */
   const units = [];
 
   for (const block of blocks) {
     if (block.group) {
       if (!groups.has(block.group)) {
-        const entry = { blocks: [], name: block.group };
+        const entry = {
+          blocks: /** @type {Block[]} */ ([]),
+          name: block.group,
+        };
         groups.set(block.group, entry);
         units.push(entry);
       }
-      groups.get(block.group).blocks.push(block);
+      /** @type {{ blocks: Block[], name: string }} */ (
+        groups.get(block.group)
+      ).blocks.push(block);
     } else {
-      units.push({ blocks: [block], name: block.tag || `line ${block.startLine}` });
+      units.push({
+        blocks: [block],
+        name: block.tag || `line ${block.startLine}`,
+      });
     }
   }
 
@@ -21,22 +47,28 @@ export function generate({ blocks }) {
     units: units.map((unit) => ({
       code: assembleUnit(unit.blocks),
       name: unit.name,
-      hasTypescript: unit.blocks.some((b) => b.lang === "typescript" || b.lang === "ts"),
+      hasTypescript: unit.blocks.some(
+        (b) => b.lang === 'typescript' || b.lang === 'ts',
+      ),
     })),
   };
 }
 
+/**
+ * @param {Block[]} blocks
+ * @returns {string}
+ */
 function assembleUnit(blocks) {
   const maxLine = Math.max(...blocks.map((b) => b.endLine));
 
-  const lines = new Array(maxLine).fill("");
+  const lines = new Array(maxLine).fill('');
 
   for (const block of blocks) {
-    const codeLines = block.code.replace(/\n$/, "").split("\n");
+    const codeLines = block.code.replace(/\n$/, '').split('\n');
     for (let i = 0; i < codeLines.length; i++) {
       lines[block.startLine - 1 + i] = codeLines[i];
     }
   }
 
-  return lines.join("\n") + "\n";
+  return lines.join('\n') + '\n';
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export { extractBlocks } from "./extract.js";
-export { commentToAssert, transform } from "./transform.js";
-export { generate } from "./generate.js";
-export { resolveMainEntry, resolveSubpathExport } from "./resolve.js";
-export { processMarkdown, run } from "./run.js";
+export { extractBlocks } from './extract.js';
+export { commentToAssert, transform } from './transform.js';
+export { generate } from './generate.js';
+export { resolveMainEntry, resolveSubpathExport } from './resolve.js';
+export { processMarkdown, run } from './run.js';

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -1,10 +1,22 @@
-import fs from "node:fs";
-import path from "node:path";
+import fs from 'node:fs';
+import path from 'node:path';
 
+/**
+ * Package.json `exports` is a recursive structure (strings or nested
+ * condition objects). JSDoc can't express recursive types, so we use
+ * a pragmatic two-level approximation.
+ *
+ * @typedef {string | Record<string, any>} ExportsEntry
+ */
+
+/**
+ * @param {string} dir
+ * @returns {string | null}
+ */
 export function findPackageJson(dir) {
   let current = path.resolve(dir);
   while (true) {
-    const candidate = path.join(current, "package.json");
+    const candidate = path.join(current, 'package.json');
     if (fs.existsSync(candidate)) return candidate;
     const parent = path.dirname(current);
     if (parent === current) return null;
@@ -22,16 +34,19 @@ export function findPackageJson(dir) {
  *   - nested:          "exports": { ".": { "import": "./esm.js" } }
  *
  * Returns null if no entry can be determined.
+ *
+ * @param {{ main?: string, exports?: ExportsEntry }} pkg
+ * @returns {string | null}
  */
 export function resolveMainEntry(pkg) {
   if (pkg.main) return pkg.main;
 
   const exp = pkg.exports;
   if (!exp) return null;
-  if (typeof exp === "string") return exp;
-  if (typeof exp !== "object") return null;
+  if (typeof exp === 'string') return exp;
+  if (typeof exp !== 'object') return null;
 
-  const root = isSubpathExportsMap(exp) ? exp["."] : exp;
+  const root = isSubpathExportsMap(exp) ? exp['.'] : exp;
 
   return resolveExportCondition(root);
 }
@@ -43,9 +58,13 @@ export function resolveMainEntry(pkg) {
  *   // => "./src/utils.js"
  *
  * Returns null when the exports map doesn't contain the subpath.
+ *
+ * @param {ExportsEntry} exportsMap
+ * @param {string} subpath
+ * @returns {string | null}
  */
 export function resolveSubpathExport(exportsMap, subpath) {
-  if (!exportsMap || typeof exportsMap !== "object") return null;
+  if (!exportsMap || typeof exportsMap !== 'object') return null;
   if (!isSubpathExportsMap(exportsMap)) return null;
   if (subpath in exportsMap) {
     return resolveExportCondition(exportsMap[subpath]);
@@ -53,13 +72,17 @@ export function resolveSubpathExport(exportsMap, subpath) {
   return null;
 }
 
+/**
+ * @param {ExportsEntry | undefined} node
+ * @returns {string | null}
+ */
 function resolveExportCondition(node) {
   if (node == null) return null;
-  if (typeof node === "string") return node;
-  if (typeof node !== "object") return null;
+  if (typeof node === 'string') return node;
+  if (typeof node !== 'object') return null;
 
   // Prefer import > default > require
-  for (const key of ["import", "default", "require"]) {
+  for (const key of ['import', 'default', 'require']) {
     if (key in node) {
       const resolved = resolveExportCondition(node[key]);
       if (resolved) return resolved;
@@ -68,6 +91,10 @@ function resolveExportCondition(node) {
   return null;
 }
 
+/**
+ * @param {Record<string, ExportsEntry>} exp
+ * @returns {boolean}
+ */
 function isSubpathExportsMap(exp) {
-  return Object.keys(exp).some((k) => k.startsWith("."));
+  return Object.keys(exp).some((k) => k.startsWith('.'));
 }

--- a/src/run.js
+++ b/src/run.js
@@ -1,24 +1,72 @@
-import fs from "node:fs";
-import path from "node:path";
-import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { extractBlocks } from "./extract.js";
-import { generate } from "./generate.js";
-import { transform } from "./transform.js";
-import { findPackageJson, resolveMainEntry, resolveSubpathExport } from "./resolve.js";
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { extractBlocks } from './extract.js';
+import { generate } from './generate.js';
+import { transform } from './transform.js';
+import {
+  findPackageJson,
+  resolveMainEntry,
+  resolveSubpathExport,
+} from './resolve.js';
 
+/**
+ * @import { TransformResult } from "./transform.js"
+ * @import { Unit } from "./generate.js"
+ */
+
+/**
+ * @typedef {{
+ *   auto?: boolean,
+ *   all?: boolean,
+ *   main?: string,
+ *   stream?: boolean,
+ *   require?: string[],
+ *   import?: string[],
+ * }} RunOptions
+ */
+
+/**
+ * @typedef {{
+ *   exitCode: number,
+ *   stdout: string,
+ *   stderr: string,
+ * }} ExecResult
+ */
+
+/**
+ * @typedef {{
+ *   exitCode: number,
+ *   stdout: string,
+ *   stderr: string,
+ *   results: (ExecResult & { name: string })[],
+ * }} RunResult
+ */
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   name: string,
+ *   isESM: boolean,
+ * }} ProcessedUnit
+ */
+
+/** @type {Set<string>} */
 const tmpFiles = new Set();
 
 function cleanupTmpFiles() {
   for (const f of tmpFiles) {
-    try { fs.unlinkSync(f); } catch {}
+    try {
+      fs.unlinkSync(f);
+    } catch {}
   }
   tmpFiles.clear();
 }
 
-process.on("exit", cleanupTmpFiles);
+process.on('exit', cleanupTmpFiles);
 
-for (const signal of ["SIGINT", "SIGTERM"]) {
+for (const signal of /** @type {const} */ (['SIGINT', 'SIGTERM'])) {
   process.once(signal, () => {
     cleanupTmpFiles();
     process.kill(process.pid, signal);
@@ -29,37 +77,40 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
  * Process a markdown file into executable code units.
  *
  * @param {string} filePath
- * @param {{ auto?: boolean, all?: boolean, main?: string }} options
- * @returns {Promise<Array<{ code: string, name: string }>>}
+ * @param {RunOptions} [options]
+ * @returns {Promise<ProcessedUnit[]>}
  */
 export async function processMarkdown(filePath, options = {}) {
-  const markdown = fs.readFileSync(filePath, "utf-8");
+  const markdown = fs.readFileSync(filePath, 'utf-8');
   const extracted = extractBlocks(markdown, {
     auto: options.auto,
     all: options.all,
   });
 
   if (extracted.blocks.length === 0) {
-    const err = new Error(`No test code blocks found in ${filePath}`);
-    err.code = "NO_TEST_BLOCKS";
+    const err = /** @type {Error & { code?: string }} */ (
+      new Error(`No test code blocks found in ${filePath}`)
+    );
+    err.code = 'NO_TEST_BLOCKS';
     throw err;
   }
 
   const { units } = generate(extracted);
 
+  /** @type {((specifier: string) => string | null) | null} */
   let resolve = null;
   const pkgPath = findPackageJson(path.dirname(filePath));
   if (pkgPath) {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (pkg.name) {
-      const mainEntry = options.main || resolveMainEntry(pkg) || "./index.js";
-      const packageName = pkg.name;
+      const mainEntry = options.main || resolveMainEntry(pkg) || './index.js';
+      const packageName = /** @type {string} */ (pkg.name);
       const packageDir = path.dirname(pkgPath);
       const localPath = path.resolve(packageDir, mainEntry);
       const exportsMap = pkg.exports;
       resolve = (specifier) => {
         if (specifier === packageName) return localPath;
-        if (specifier.startsWith(packageName + "/")) {
+        if (specifier.startsWith(packageName + '/')) {
           const sub = specifier.slice(packageName.length + 1);
           if (exportsMap) {
             const resolved = resolveSubpathExport(exportsMap, `./${sub}`);
@@ -72,6 +123,7 @@ export async function processMarkdown(filePath, options = {}) {
     }
   }
 
+  /** @type {ProcessedUnit[]} */
   const results = [];
   for (const unit of units) {
     let code = unit.code;
@@ -80,22 +132,24 @@ export async function processMarkdown(filePath, options = {}) {
       typescript: unit.hasTypescript,
       renameImports: resolve,
       hoistImports: true,
-      requireMode: options.require?.length > 0,
+      requireMode: (options.require?.length ?? 0) > 0,
       sourceMapSource: filePath,
     });
     code = transformed.code;
 
     if (unit.hasTypescript) {
-      const esbuild = await import("esbuild");
+      const esbuild = await import('esbuild');
       const result = await esbuild.transform(code, {
-        loader: "ts",
+        loader: 'ts',
         sourcemap: false,
       });
       code = result.code;
     }
 
     if (transformed.map) {
-      const mapBase64 = Buffer.from(JSON.stringify(transformed.map)).toString("base64");
+      const mapBase64 = Buffer.from(JSON.stringify(transformed.map)).toString(
+        'base64',
+      );
       code += `\n//# sourceMappingURL=data:application/json;base64,${mapBase64}\n`;
     }
 
@@ -117,40 +171,52 @@ export async function processMarkdown(filePath, options = {}) {
  * programmatic callers.
  *
  * @param {string} filePath
- * @param {{ auto?: boolean, all?: boolean, main?: string, stream?: boolean }} options
- * @returns {Promise<{ exitCode: number, stdout: string, stderr: string, results: Array }>}
+ * @param {RunOptions} [options]
+ * @returns {Promise<RunResult>}
  */
 export async function run(filePath, options = {}) {
   const units = await processMarkdown(filePath, options);
   const dir = path.dirname(filePath);
-  let allStdout = "";
-  let allStderr = "";
+  let allStdout = '';
+  let allStderr = '';
+  /** @type {(ExecResult & { name: string })[]} */
   const results = [];
 
   const stream = options.stream ?? false;
 
   for (const unit of units) {
     const code = unit.code;
-    const ext = unit.isESM ? ".mjs" : ".cjs";
-    const tmpFile = path.join(dir, `.readme-assert-${randomUUID().slice(0, 8)}${ext}`);
+    const ext = unit.isESM ? '.mjs' : '.cjs';
+    const tmpFile = path.join(
+      dir,
+      `.readme-assert-${randomUUID().slice(0, 8)}${ext}`,
+    );
     tmpFiles.add(tmpFile);
     fs.writeFileSync(tmpFile, code);
 
     try {
-      const nodeArgs = ["--enable-source-maps"];
-      for (const r of options.require || []) nodeArgs.push("--require", r);
-      for (const i of options.import || []) nodeArgs.push("--import", i);
+      /** @type {string[]} */
+      const nodeArgs = ['--enable-source-maps'];
+      for (const r of options.require || []) nodeArgs.push('--require', r);
+      for (const i of options.import || []) nodeArgs.push('--import', i);
       nodeArgs.push(tmpFile);
-      const result = await exec("node", nodeArgs, dir, filePath, stream);
+      const result = await exec('node', nodeArgs, dir, filePath, stream);
       allStdout += result.stdout;
       allStderr += result.stderr;
       results.push({ name: unit.name, ...result });
 
       if (result.exitCode !== 0) {
-        return { exitCode: result.exitCode, stdout: allStdout, stderr: allStderr, results };
+        return {
+          exitCode: result.exitCode,
+          stdout: allStdout,
+          stderr: allStderr,
+          results,
+        };
       }
     } finally {
-      try { fs.unlinkSync(tmpFile); } catch {}
+      try {
+        fs.unlinkSync(tmpFile);
+      } catch {}
       tmpFiles.delete(tmpFile);
     }
   }
@@ -158,21 +224,29 @@ export async function run(filePath, options = {}) {
   return { exitCode: 0, stdout: allStdout, stderr: allStderr, results };
 }
 
+/**
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {string} cwd
+ * @param {string} mdPath
+ * @param {boolean} stream
+ * @returns {Promise<ExecResult>}
+ */
 function exec(cmd, args, cwd, mdPath, stream) {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    let stdout = "";
-    let stderr = "";
+    const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    let stdout = '';
+    let stderr = '';
 
-    child.stdout.on("data", (chunk) => {
+    child.stdout.on('data', (/** @type {string} */ chunk) => {
       if (stream) process.stdout.write(chunk);
       stdout += chunk;
     });
-    child.stderr.on("data", (d) => (stderr += d));
+    child.stderr.on('data', (/** @type {string} */ d) => (stderr += d));
 
-    child.on("close", (exitCode) => {
+    child.on('close', (/** @type {number | null} */ exitCode) => {
       const tmpFile = args[args.length - 1];
       stderr = stderr.replaceAll(tmpFile, mdPath);
       stdout = stdout.replaceAll(tmpFile, mdPath);
@@ -181,19 +255,27 @@ function exec(cmd, args, cwd, mdPath, stream) {
         stderr = formatError(stderr, mdPath);
       }
 
-      resolve({ exitCode, stdout, stderr });
+      resolve({ exitCode: exitCode ?? 1, stdout, stderr });
     });
   });
 }
 
+/**
+ * @param {string} stderr
+ * @param {string} mdPath
+ * @returns {string}
+ */
 function formatError(stderr, mdPath) {
-  const locMatch = stderr.match(new RegExp(`${escapeRegExp(mdPath)}:(\\d+):(\\d+)`));
+  const locMatch = stderr.match(
+    new RegExp(`${escapeRegExp(mdPath)}:(\\d+):(\\d+)`),
+  );
   const line = locMatch ? parseInt(locMatch[1]) : null;
   const actualMatch = stderr.match(/actual: (.+)/);
   const expectedMatch = stderr.match(/expected: (.+)/);
   const msgMatch = stderr.match(/AssertionError.*?:\s*(.+)/);
   const genericMatch = !msgMatch && stderr.match(/(\w*Error.*)/);
 
+  /** @type {string[]} */
   const parts = [];
   const relPath = path.relative(process.cwd(), mdPath);
   if (line) {
@@ -204,45 +286,54 @@ function formatError(stderr, mdPath) {
 
   if (line) {
     try {
-      const mdLines = fs.readFileSync(mdPath, "utf-8").split("\n");
+      const mdLines = fs.readFileSync(mdPath, 'utf-8').split('\n');
       const start = Math.max(0, line - 3);
       const end = Math.min(mdLines.length, line + 2);
       for (let i = start; i < end; i++) {
         const lineNum = String(i + 1).padStart(4);
-        const marker = i + 1 === line ? " > " : "   ";
+        const marker = i + 1 === line ? ' > ' : '   ';
         parts.push(`${marker}${lineNum} | ${mdLines[i]}`);
       }
-      parts.push("");
+      parts.push('');
     } catch {
       // ignore read errors
     }
   }
 
   if (actualMatch && expectedMatch) {
-    parts.push(`  expected: ${expectedMatch[1].replace(/,\s*$/, "")}`);
-    parts.push(`  received: ${actualMatch[1].replace(/,\s*$/, "")}`);
-    parts.push("");
+    parts.push(`  expected: ${expectedMatch[1].replace(/,\s*$/, '')}`);
+    parts.push(`  received: ${actualMatch[1].replace(/,\s*$/, '')}`);
+    parts.push('');
   } else if (msgMatch) {
     parts.push(`  ${msgMatch[0]}`);
-    parts.push("");
+    parts.push('');
   } else if (genericMatch) {
     parts.push(`  ${genericMatch[1]}`);
-    parts.push("");
+    parts.push('');
   } else {
     // Fallback: strip Node internals and return cleaned stderr
     parts.push(
       stderr
-        .split("\n")
-        .filter((l) => !l.match(/^\s*(at [a-z].*\(node:|node:internal|Node\.js v|triggerUncaught|\^$)/i))
-        .join("\n")
+        .split('\n')
+        .filter(
+          (l) =>
+            !l.match(
+              /^\s*(at [a-z].*\(node:|node:internal|Node\.js v|triggerUncaught|\^$)/i,
+            ),
+        )
+        .join('\n')
         .trim(),
     );
-    parts.push("");
+    parts.push('');
   }
 
-  return parts.join("\n");
+  return parts.join('\n');
 }
 
+/**
+ * @param {string} s
+ * @returns {string}
+ */
 function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,6 +1,6 @@
-import { parseSync } from "oxc-parser";
-import { print } from "esrap";
-import ts from "esrap/languages/ts";
+import { parseSync } from 'oxc-parser';
+import { print } from 'esrap';
+import ts from 'esrap/languages/ts';
 import {
   assertCommentRe,
   walkAst,
@@ -12,43 +12,101 @@ import {
   findTrailingComment,
   addLoc,
   stampLoc,
-} from "./ast.js";
+} from './ast.js';
 
+/**
+ * @import { Comment } from "oxc-parser"
+ * @import { AstNode, SourceLocation } from "./ast.js"
+ */
+
+/**
+ * @typedef {{
+ *   code: string,
+ *   map: any,
+ *   isESM: boolean,
+ * }} TransformResult
+ */
+
+/**
+ * @typedef {{
+ *   typescript?: boolean,
+ *   renameImports?: ((specifier: string) => string | null) | null,
+ *   hoistImports?: boolean,
+ *   requireMode?: boolean,
+ *   sourceMapSource?: string | null,
+ * }} TransformOptions
+ */
+
+/**
+ * @param {string} code
+ * @param {{ typescript?: boolean }} [options]
+ * @returns {TransformResult}
+ */
 export function commentToAssert(code, { typescript = false } = {}) {
   if (!assertCommentRe.test(code)) return { code, map: null, isESM: false };
   return transform(code, { typescript });
 }
 
-export function transform(code, {
-  typescript = false,
-  renameImports = null,
-  hoistImports = false,
-  requireMode = false,
-  sourceMapSource = null,
-} = {}) {
-  const ext = typescript ? "test.ts" : "test.js";
+/**
+ * @param {string} code
+ * @param {TransformOptions} [options]
+ * @returns {TransformResult}
+ */
+export function transform(
+  code,
+  {
+    typescript = false,
+    renameImports = null,
+    hoistImports = false,
+    requireMode = false,
+    sourceMapSource = null,
+  } = {},
+) {
+  const ext = typescript ? 'test.ts' : 'test.js';
   const result = parseSync(ext, code);
   const ast = result.program;
   const comments = result.comments;
 
-  addLoc(ast, code);
+  addLoc(/** @type {AstNode} */ (/** @type {unknown} */ (ast)), code);
 
   let isESM = false;
   if (hoistImports) {
-    isESM = doHoist(ast, code, renameImports, requireMode);
+    isESM = doHoist(
+      /** @type {AstNode} */ (/** @type {unknown} */ (ast)),
+      code,
+      renameImports,
+      requireMode,
+    );
   }
 
-  applyAssertions(ast, comments, code);
+  applyAssertions(
+    /** @type {AstNode} */ (/** @type {unknown} */ (ast)),
+    comments,
+    code,
+  );
 
-  const printed = print(ast, ts(), {
+  const printed = print(/** @type {any} */ (ast), ts(), {
     sourceMapSource: sourceMapSource || undefined,
     sourceMapContent: sourceMapSource ? code : undefined,
   });
-  return { code: printed.code, map: sourceMapSource ? printed.map : null, isESM };
+  return {
+    code: printed.code,
+    map: sourceMapSource ? printed.map : null,
+    isESM,
+  };
 }
 
+/**
+ * @param {AstNode} ast
+ * @param {string} code
+ * @param {((specifier: string) => string | null) | null} resolve
+ * @param {boolean} requireMode
+ * @returns {boolean}
+ */
 function doHoist(ast, code, resolve, requireMode) {
+  /** @type {AstNode[]} */
   const declarations = [];
+  /** @type {AstNode[]} */
   const body = [];
 
   for (const node of ast.body) {
@@ -61,7 +119,9 @@ function doHoist(ast, code, resolve, requireMode) {
   }
 
   if (resolve) {
-    for (const call of findRequireCalls({ body })) {
+    for (const call of findRequireCalls(
+      /** @type {AstNode} */ (/** @type {unknown} */ ({ body })),
+    )) {
       renameStringLiteral(call.arguments[0], resolve);
     }
   }
@@ -71,14 +131,16 @@ function doHoist(ast, code, resolve, requireMode) {
   let hasRequire = false;
   for (const node of body) {
     walkAst(node, (n) => {
-      if (n.type === "AwaitExpression") hasAwait = true;
+      if (n.type === 'AwaitExpression') hasAwait = true;
       if (isRequireCall(n)) hasRequire = true;
     });
     if (hasAwait && hasRequire) break;
   }
   const hasCJS = !hasAwait && !hasESM && hasRequire;
 
+  /** @type {string} */
   let assertCode;
+  /** @type {boolean} */
   let isESM;
   if (hasESM) {
     assertCode = 'import assert from "node:assert/strict";';
@@ -87,18 +149,26 @@ function doHoist(ast, code, resolve, requireMode) {
     assertCode = 'const assert = require("node:assert/strict");';
     isESM = false;
   } else {
-    assertCode = 'const { default: assert } = await import("node:assert/strict");';
+    assertCode =
+      'const { default: assert } = await import("node:assert/strict");';
     isESM = true;
   }
 
-  const assertNode = parseSync("t.js", assertCode).program.body[0];
+  const assertNode = /** @type {AstNode} */ (
+    /** @type {unknown} */ (parseSync('t.js', assertCode).program.body[0])
+  );
   const firstNode = declarations[0] || body[0];
-  if (firstNode) stampLoc(assertNode, firstNode.loc);
+  if (firstNode)
+    stampLoc(assertNode, /** @type {SourceLocation} */ (firstNode.loc));
   ast.body = [assertNode, ...declarations, ...body];
 
   return isESM;
 }
 
+/**
+ * @param {AstNode} node
+ * @param {(specifier: string) => string | null} resolve
+ */
 function renameSpecifiers(node, resolve) {
   const source = getSourceNode(node);
   if (source) renameStringLiteral(source, resolve);
@@ -107,6 +177,10 @@ function renameSpecifiers(node, resolve) {
   }
 }
 
+/**
+ * @param {AstNode} literal
+ * @param {(specifier: string) => string | null} resolve
+ */
 function renameStringLiteral(literal, resolve) {
   const newPath = resolve(literal.value);
   if (newPath) {
@@ -115,21 +189,27 @@ function renameStringLiteral(literal, resolve) {
   }
 }
 
+/**
+ * @param {AstNode} ast
+ * @param {Comment[]} comments
+ * @param {string} code
+ */
 function applyAssertions(ast, comments, code) {
   for (let i = 0; i < ast.body.length; i++) {
-    const node = ast.body[i];
-    if (node.type !== "ExpressionStatement") continue;
+    const node = /** @type {AstNode} */ (ast.body[i]);
+    if (node.type !== 'ExpressionStatement') continue;
 
     const comment = findTrailingComment(comments, node, code);
     if (!comment) continue;
 
-    const isAwait = node.expression.type === "AwaitExpression";
+    const isAwait = node.expression.type === 'AwaitExpression';
     const expr = node.expression;
 
     const match = comment.value.match(/^\s*(=>|→|->)\s*([\s\S]*)$/);
     const throwsMatch = comment.value.match(/^\s*throws\s+([\s\S]*)$/);
     const rejectsMatch = comment.value.match(/^\s*rejects\s+([\s\S]*)$/);
 
+    /** @type {AstNode[] | undefined} */
     let newNodes;
 
     if (match) {
@@ -143,103 +223,197 @@ function applyAssertions(ast, comments, code) {
 
       if (resolvesMatch) {
         const val = parseExpr(resolvesMatch[1].trim());
-        newNodes = [stmt(assertCall("deepEqual", [awaitNode(expr), val]))];
+        newNodes = [stmt(assertCall('deepEqual', [awaitNode(expr), val]))];
       } else if (rejectsErrorMatch) {
-        const matcher = errorMatcher(rejectsErrorMatch[1], rejectsErrorMatch[2]?.trim());
-        newNodes = [throwsOrRejects(expr, matcher, { isAwait, useRejects: true })];
+        const matcher = errorMatcher(
+          rejectsErrorMatch[1],
+          rejectsErrorMatch[2]?.trim(),
+        );
+        newNodes = [
+          throwsOrRejects(expr, matcher, { isAwait, useRejects: true }),
+        ];
       } else if (errorMatch) {
         const matcher = errorMatcher(errorMatch[1], errorMatch[2]?.trim());
-        newNodes = [throwsOrRejects(expr, matcher, { isAwait, useRejects: false })];
+        newNodes = [
+          throwsOrRejects(expr, matcher, { isAwait, useRejects: false }),
+        ];
       } else if (isConsoleCall(expr)) {
         const arg = expr.arguments[0];
         const val = parseExpr(rest);
-        newNodes = [node, stmt(assertCall("deepEqual", [arg, val]))];
+        newNodes = [node, stmt(assertCall('deepEqual', [arg, val]))];
       } else {
         const val = parseExpr(rest);
-        newNodes = [stmt(assertCall("deepEqual", [expr, val]))];
+        newNodes = [stmt(assertCall('deepEqual', [expr, val]))];
       }
     } else if (throwsMatch) {
       const matcher = parseExpr(throwsMatch[1].trim());
-      newNodes = [throwsOrRejects(expr, matcher, { isAwait, useRejects: false })];
+      newNodes = [
+        throwsOrRejects(expr, matcher, { isAwait, useRejects: false }),
+      ];
     } else if (rejectsMatch) {
       const matcher = parseExpr(rejectsMatch[1].trim());
-      newNodes = [throwsOrRejects(expr, matcher, { isAwait, useRejects: true })];
+      newNodes = [
+        throwsOrRejects(expr, matcher, { isAwait, useRejects: true }),
+      ];
     }
 
     if (newNodes) {
-      for (const n of newNodes) stampLoc(n, node.loc);
+      for (const n of newNodes)
+        stampLoc(n, /** @type {SourceLocation} */ (node.loc));
       ast.body.splice(i, 1, ...newNodes);
       i += newNodes.length - 1;
     }
   }
 }
 
+// --- AST node builders ---
+
+/**
+ * @param {string} text
+ * @returns {AstNode}
+ */
 function parseExpr(text) {
-  const expr = parseSync("t.js", `(${text})`, { preserveParens: false }).program.body[0].expression;
-  return expr.type === "ParenthesizedExpression" ? expr.expression : expr;
+  const expr = parseSync('t.js', `(${text})`, { preserveParens: false }).program
+    .body[0];
+  const exprStmt = /** @type {AstNode} */ (/** @type {unknown} */ (expr));
+  return exprStmt.expression.type === 'ParenthesizedExpression'
+    ? exprStmt.expression.expression
+    : exprStmt.expression;
 }
 
+/**
+ * @param {string} name
+ * @returns {AstNode}
+ */
 function id(name) {
-  return { type: "Identifier", name };
+  return { type: 'Identifier', name };
 }
 
+/**
+ * @param {string} value
+ * @returns {AstNode}
+ */
 function literal(value) {
-  return { type: "Literal", value, raw: JSON.stringify(value) };
+  return { type: 'Literal', value, raw: JSON.stringify(value) };
 }
 
+/**
+ * @param {AstNode} obj
+ * @param {string} prop
+ * @returns {AstNode}
+ */
 function member(obj, prop) {
-  return { type: "MemberExpression", object: obj, property: id(prop), computed: false, optional: false };
+  return {
+    type: 'MemberExpression',
+    object: obj,
+    property: id(prop),
+    computed: false,
+    optional: false,
+  };
 }
 
+/**
+ * @param {AstNode} callee
+ * @param {AstNode[]} args
+ * @returns {AstNode}
+ */
 function call(callee, args) {
-  return { type: "CallExpression", callee, arguments: args };
+  return { type: 'CallExpression', callee, arguments: args };
 }
 
+/**
+ * @param {AstNode} expr
+ * @returns {AstNode}
+ */
 function stmt(expr) {
-  return { type: "ExpressionStatement", expression: expr };
+  return { type: 'ExpressionStatement', expression: expr };
 }
 
+/**
+ * @param {AstNode} arg
+ * @returns {AstNode}
+ */
 function awaitNode(arg) {
-  return { type: "AwaitExpression", argument: arg };
+  return { type: 'AwaitExpression', argument: arg };
 }
 
+/**
+ * @param {AstNode | AstNode[]} body
+ * @param {{ async?: boolean, expression?: boolean }} [options]
+ * @returns {AstNode}
+ */
 function arrow(body, { async: isAsync = false, expression = false } = {}) {
   return {
-    type: "ArrowFunctionExpression",
+    type: 'ArrowFunctionExpression',
     params: [],
-    body: expression ? body : { type: "BlockStatement", body },
+    body: expression ? body : { type: 'BlockStatement', body },
     async: isAsync,
     expression,
   };
 }
 
+/**
+ * @param {string} key
+ * @param {AstNode} value
+ * @returns {AstNode}
+ */
 function prop(key, value) {
-  return { type: "Property", key: id(key), value, kind: "init", computed: false, method: false, shorthand: false };
+  return {
+    type: 'Property',
+    key: id(key),
+    value,
+    kind: 'init',
+    computed: false,
+    method: false,
+    shorthand: false,
+  };
 }
 
+/**
+ * @param {AstNode[]} properties
+ * @returns {AstNode}
+ */
 function obj(properties) {
-  return { type: "ObjectExpression", properties };
+  return { type: 'ObjectExpression', properties };
 }
 
+/**
+ * @param {string} method
+ * @param {AstNode[]} args
+ * @returns {AstNode}
+ */
 function assertCall(method, args) {
-  return call(member(id("assert"), method), args);
+  return call(member(id('assert'), method), args);
 }
 
+/**
+ * @param {string} name
+ * @param {string | undefined} message
+ * @returns {AstNode}
+ */
 function errorMatcher(name, message) {
-  const props = [prop("name", literal(name))];
+  const props = [prop('name', literal(name))];
   if (message) {
     const reMatch = message.match(/^\/(.+)\/([gimsuy]*)$/);
-    props.push(prop("message", reMatch ? parseExpr(message) : literal(message)));
+    props.push(
+      prop('message', reMatch ? parseExpr(message) : literal(message)),
+    );
   }
   return obj(props);
 }
 
+/**
+ * @param {AstNode} expr
+ * @param {AstNode} matcher
+ * @param {{ isAwait: boolean, useRejects: boolean }} options
+ * @returns {AstNode}
+ */
 function throwsOrRejects(expr, matcher, { isAwait, useRejects }) {
   if (isAwait || useRejects) {
     const fn = isAwait
       ? arrow([stmt(expr)], { async: true })
       : arrow(expr, { expression: true });
-    return stmt(awaitNode(assertCall("rejects", [fn, matcher])));
+    return stmt(awaitNode(assertCall('rejects', [fn, matcher])));
   }
-  return stmt(assertCall("throws", [arrow([stmt(expr)]), matcher]));
+  return stmt(assertCall('throws', [arrow([stmt(expr)]), matcher]));
 }

--- a/test/comment-to-assert.test.js
+++ b/test/comment-to-assert.test.js
@@ -1,205 +1,239 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { commentToAssert } from "../src/transform.js";
-import { parse, assertCall, assertAwaitedCall, methodName } from "./helpers.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { commentToAssert } from '../src/transform.js';
+import { parse, assertCall, assertAwaitedCall, methodName } from './helpers.js';
 
-describe("commentToAssert", () => {
-  it("transforms //=> to assert.deepEqual", () => {
-    const call = assertCall(commentToAssert("1 + 1 //=> 2").code);
-    assert.equal(methodName(call), "assert.deepEqual");
+describe('commentToAssert', () => {
+  it('transforms //=> to assert.deepEqual', () => {
+    const call = assertCall(commentToAssert('1 + 1 //=> 2').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
     assert.equal(call.arguments.length, 2);
   });
 
-  it("transforms // => with space", () => {
-    const call = assertCall(commentToAssert("x // => 42").code);
-    assert.equal(methodName(call), "assert.deepEqual");
+  it('transforms // => with space', () => {
+    const call = assertCall(commentToAssert('x // => 42').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
   });
 
-  it("transforms // → with utf-8 arrow", () => {
-    const call = assertCall(commentToAssert("a // → 1").code);
-    assert.equal(methodName(call), "assert.deepEqual");
+  it('transforms // → with utf-8 arrow', () => {
+    const call = assertCall(commentToAssert('a // → 1').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
   });
 
-  it("transforms // -> with ascii arrow", () => {
-    const call = assertCall(commentToAssert("a // -> 1").code);
-    assert.equal(methodName(call), "assert.deepEqual");
+  it('transforms // -> with ascii arrow', () => {
+    const call = assertCall(commentToAssert('a // -> 1').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
   });
 
-  it("transforms // throws to assert.throws", () => {
-    const call = assertCall(commentToAssert("fn() // throws /err/").code);
-    assert.equal(methodName(call), "assert.throws");
-    assert.equal(call.arguments[0].type, "ArrowFunctionExpression");
-    assert.equal(call.arguments[1].type, "Literal");
+  it('transforms // throws to assert.throws', () => {
+    const call = assertCall(commentToAssert('fn() // throws /err/').code);
+    assert.equal(methodName(call), 'assert.throws');
+    assert.equal(call.arguments[0].type, 'ArrowFunctionExpression');
+    assert.equal(call.arguments[1].type, 'Literal');
   });
 
-  it("handles console.log: keeps log and adds assertion", () => {
-    const body = parse(commentToAssert('console.log(a) //=> { a: 1 }').code).body;
+  it('handles console.log: keeps log and adds assertion', () => {
+    const body = parse(
+      commentToAssert('console.log(a) //=> { a: 1 }').code,
+    ).body;
     const calls = body
-      .filter((n) => n.type === "ExpressionStatement")
+      .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression);
-    assert.ok(calls.some((c) => c.callee?.object?.name === "console"));
-    assert.ok(calls.some((c) => methodName(c) === "assert.deepEqual"));
+    assert.ok(calls.some((c) => c.callee?.object?.name === 'console'));
+    assert.ok(calls.some((c) => methodName(c) === 'assert.deepEqual'));
   });
 
-  it("console.log with multiple statements", () => {
-    const body = parse(commentToAssert("console.log(a) //=> 1\nlet b = 2;\nb; //=> 2").code).body;
+  it('console.log with multiple statements', () => {
+    const body = parse(
+      commentToAssert('console.log(a) //=> 1\nlet b = 2;\nb; //=> 2').code,
+    ).body;
     const calls = body
-      .filter((n) => n.type === "ExpressionStatement")
+      .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression)
-      .filter((e) => e.type === "CallExpression");
+      .filter((e) => e.type === 'CallExpression');
     const methods = calls.map(methodName);
-    assert.ok(methods.includes("assert.deepEqual"));
-    assert.ok(methods.includes("console.log"));
+    assert.ok(methods.includes('assert.deepEqual'));
+    assert.ok(methods.includes('console.log'));
   });
 
-  it("handles object expected values", () => {
-    const call = assertCall(commentToAssert("x //=> { a: 1, b: 2 }").code);
-    assert.equal(methodName(call), "assert.deepEqual");
-    assert.equal(call.arguments[1].type, "ObjectExpression");
+  it('handles object expected values', () => {
+    const call = assertCall(commentToAssert('x //=> { a: 1, b: 2 }').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(call.arguments[1].type, 'ObjectExpression');
   });
 
-  it("handles array expected values", () => {
-    const call = assertCall(commentToAssert("arr //=> [1, 2, 3]").code);
-    assert.equal(methodName(call), "assert.deepEqual");
-    assert.equal(call.arguments[1].type, "ArrayExpression");
+  it('handles array expected values', () => {
+    const call = assertCall(commentToAssert('arr //=> [1, 2, 3]').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(call.arguments[1].type, 'ArrayExpression');
   });
 
-  it("handles await expression with //=> value", () => {
-    const call = assertCall(commentToAssert("await Promise.resolve(true) //=> true").code);
-    assert.equal(methodName(call), "assert.deepEqual");
-    assert.equal(call.arguments[0].type, "AwaitExpression");
+  it('handles await expression with //=> value', () => {
+    const call = assertCall(
+      commentToAssert('await Promise.resolve(true) //=> true').code,
+    );
+    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 
-  it("handles string expected values", () => {
+  it('handles string expected values', () => {
     const call = assertCall(commentToAssert('x //=> "hello"').code);
-    assert.equal(call.arguments[1].value, "hello");
+    assert.equal(call.arguments[1].value, 'hello');
   });
 
-  it("leaves non-assertion code untouched", () => {
-    const input = "const x = 1;\nconst y = 2;";
+  it('leaves non-assertion code untouched', () => {
+    const input = 'const x = 1;\nconst y = 2;';
     assert.equal(commentToAssert(input).code, input);
   });
 
-  it("ignores //=> with no value after it", () => {
-    const { code } = commentToAssert("x //=>\n");
+  it('ignores //=> with no value after it', () => {
+    const { code } = commentToAssert('x //=>\n');
     const body = parse(code).body;
     const calls = body
-      .filter((n) => n.type === "ExpressionStatement")
+      .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression)
-      .filter((e) => e.type === "CallExpression");
+      .filter((e) => e.type === 'CallExpression');
     assert.equal(calls.length, 0);
   });
 
-  it("handles multiple assertions", () => {
-    const body = parse(commentToAssert("a //=> 1\nb //=> 2").code).body;
+  it('handles multiple assertions', () => {
+    const body = parse(commentToAssert('a //=> 1\nb //=> 2').code).body;
     const calls = body
-      .filter((n) => n.type === "ExpressionStatement")
+      .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression);
     assert.equal(calls.length, 2);
-    assert.ok(calls.every((c) => methodName(c) === "assert.deepEqual"));
+    assert.ok(calls.every((c) => methodName(c) === 'assert.deepEqual'));
   });
 
-  it("leaves regular comments alone", () => {
-    const input = "// this is a comment\nconst x = 1;";
+  it('leaves regular comments alone', () => {
+    const input = '// this is a comment\nconst x = 1;';
     assert.equal(commentToAssert(input).code, input);
   });
 
-  it("handles throws with regex flags", () => {
-    const call = assertCall(commentToAssert("fn() // throws /err/i").code);
-    assert.equal(methodName(call), "assert.throws");
+  it('handles throws with regex flags', () => {
+    const call = assertCall(commentToAssert('fn() // throws /err/i').code);
+    assert.equal(methodName(call), 'assert.throws');
     assert.match(call.arguments[1].raw, /\/err\/i/);
   });
 
-  it("transforms //=> resolves to value", () => {
-    const call = assertCall(commentToAssert("Promise.resolve(true) //=> resolves to true").code);
-    assert.equal(methodName(call), "assert.deepEqual");
-    assert.equal(call.arguments[0].type, "AwaitExpression");
+  it('transforms //=> resolves to value', () => {
+    const call = assertCall(
+      commentToAssert('Promise.resolve(true) //=> resolves to true').code,
+    );
+    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 
   it("transforms //=> resolves value (without 'to')", () => {
-    const call = assertCall(commentToAssert("fetch() //=> resolves 42").code);
-    assert.equal(methodName(call), "assert.deepEqual");
-    assert.equal(call.arguments[0].type, "AwaitExpression");
+    const call = assertCall(commentToAssert('fetch() //=> resolves 42').code);
+    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 
-  it("transforms // rejects", () => {
-    const call = assertCall(commentToAssert("fetch() // rejects /not found/").code);
-    assert.equal(methodName(call), "assert.rejects");
-    assert.equal(call.arguments[1].type, "Literal");
-  });
-
-  it("transforms //=> rejects Error: message", () => {
-    const call = assertCall(commentToAssert("fetch() //=> rejects Error: not found").code);
-    assert.equal(methodName(call), "assert.rejects");
-    assert.equal(call.arguments[1].type, "ObjectExpression");
-  });
-
-  it("transforms //=> rejects TypeError: /regex/", () => {
-    const call = assertCall(commentToAssert("fetch() //=> rejects TypeError: /timeout/i").code);
-    assert.equal(methodName(call), "assert.rejects");
-  });
-
-  it("transforms //=> rejects RangeError without message", () => {
-    const call = assertCall(commentToAssert("fetch() //=> rejects RangeError").code);
-    assert.equal(methodName(call), "assert.rejects");
-  });
-
-  it("transforms //=> Error: message to assert.throws", () => {
-    const call = assertCall(commentToAssert("JSON.parse(bad) //=> Error: Unexpected token").code);
-    assert.equal(methodName(call), "assert.throws");
-    assert.equal(call.arguments[1].type, "ObjectExpression");
-  });
-
-  it("transforms //=> TypeError: message to assert.throws with name", () => {
+  it('transforms // rejects', () => {
     const call = assertCall(
-      commentToAssert("obj.name //=> TypeError: Cannot read property 'name' of undefined").code,
+      commentToAssert('fetch() // rejects /not found/').code,
     );
-    assert.equal(methodName(call), "assert.throws");
+    assert.equal(methodName(call), 'assert.rejects');
+    assert.equal(call.arguments[1].type, 'Literal');
   });
 
-  it("transforms //=> TypeError: /regex/ to assert.throws with regex message", () => {
-    const call = assertCall(commentToAssert("fn() //=> TypeError: /bad input/").code);
-    assert.equal(methodName(call), "assert.throws");
+  it('transforms //=> rejects Error: message', () => {
+    const call = assertCall(
+      commentToAssert('fetch() //=> rejects Error: not found').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
+    assert.equal(call.arguments[1].type, 'ObjectExpression');
   });
 
-  it("transforms //=> Error: /regex/ with flags", () => {
-    const call = assertCall(commentToAssert("fn() //=> Error: /missing \\w+/i").code);
-    assert.equal(methodName(call), "assert.throws");
+  it('transforms //=> rejects TypeError: /regex/', () => {
+    const call = assertCall(
+      commentToAssert('fetch() //=> rejects TypeError: /timeout/i').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
   });
 
-  it("transforms //=> RangeError without message", () => {
-    const call = assertCall(commentToAssert("fn() //=> RangeError").code);
-    assert.equal(methodName(call), "assert.throws");
+  it('transforms //=> rejects RangeError without message', () => {
+    const call = assertCall(
+      commentToAssert('fetch() //=> rejects RangeError').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
   });
 
-  it("promotes await expr //=> Error: to async rejects", () => {
-    const call = assertAwaitedCall(commentToAssert("await fetch() //=> Error: not found").code);
-    assert.equal(methodName(call), "assert.rejects");
+  it('transforms //=> Error: message to assert.throws', () => {
+    const call = assertCall(
+      commentToAssert('JSON.parse(bad) //=> Error: Unexpected token').code,
+    );
+    assert.equal(methodName(call), 'assert.throws');
+    assert.equal(call.arguments[1].type, 'ObjectExpression');
+  });
+
+  it('transforms //=> TypeError: message to assert.throws with name', () => {
+    const call = assertCall(
+      commentToAssert(
+        "obj.name //=> TypeError: Cannot read property 'name' of undefined",
+      ).code,
+    );
+    assert.equal(methodName(call), 'assert.throws');
+  });
+
+  it('transforms //=> TypeError: /regex/ to assert.throws with regex message', () => {
+    const call = assertCall(
+      commentToAssert('fn() //=> TypeError: /bad input/').code,
+    );
+    assert.equal(methodName(call), 'assert.throws');
+  });
+
+  it('transforms //=> Error: /regex/ with flags', () => {
+    const call = assertCall(
+      commentToAssert('fn() //=> Error: /missing \\w+/i').code,
+    );
+    assert.equal(methodName(call), 'assert.throws');
+  });
+
+  it('transforms //=> RangeError without message', () => {
+    const call = assertCall(commentToAssert('fn() //=> RangeError').code);
+    assert.equal(methodName(call), 'assert.throws');
+  });
+
+  it('promotes await expr //=> Error: to async rejects', () => {
+    const call = assertAwaitedCall(
+      commentToAssert('await fetch() //=> Error: not found').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
     assert.equal(call.arguments[0].async, true);
   });
 
-  it("promotes await expr // throws to async rejects", () => {
-    const call = assertAwaitedCall(commentToAssert("await fn() // throws /err/").code);
-    assert.equal(methodName(call), "assert.rejects");
+  it('promotes await expr // throws to async rejects', () => {
+    const call = assertAwaitedCall(
+      commentToAssert('await fn() // throws /err/').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
   });
 
-  it("wraps await expr // rejects in async callback", () => {
-    const call = assertAwaitedCall(commentToAssert("await fetch() // rejects /err/").code);
-    assert.equal(methodName(call), "assert.rejects");
+  it('wraps await expr // rejects in async callback', () => {
+    const call = assertAwaitedCall(
+      commentToAssert('await fetch() // rejects /err/').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
   });
 
-  it("wraps await expr //=> rejects Error: in async callback", () => {
-    const call = assertAwaitedCall(commentToAssert("await fetch() //=> rejects TypeError: timeout").code);
-    assert.equal(methodName(call), "assert.rejects");
+  it('wraps await expr //=> rejects Error: in async callback', () => {
+    const call = assertAwaitedCall(
+      commentToAssert('await fetch() //=> rejects TypeError: timeout').code,
+    );
+    assert.equal(methodName(call), 'assert.rejects');
     assert.equal(call.arguments[0].async, true);
   });
 
-  it("escapes double quotes in error message strings", () => {
-    const call = assertCall(commentToAssert('fn() //=> Error: expected "foo"').code);
-    assert.equal(methodName(call), "assert.throws");
+  it('escapes double quotes in error message strings', () => {
+    const call = assertCall(
+      commentToAssert('fn() //=> Error: expected "foo"').code,
+    );
+    assert.equal(methodName(call), 'assert.throws');
     const matcher = call.arguments[1];
     const msgProp = matcher.properties.find(
-      (p) => p.key.name === "message" || p.key.value === "message",
+      (p) => p.key.name === 'message' || p.key.value === 'message',
     );
     assert.ok(msgProp.value.value.includes('"foo"'));
   });

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -1,151 +1,135 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { extractBlocks } from "../src/extract.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractBlocks } from '../src/extract.js';
 
-describe("extractBlocks", () => {
-  it("extracts tagged test blocks", () => {
+describe('extractBlocks', () => {
+  it('extracts tagged test blocks', () => {
     const md = [
-      "# Hello",
-      "",
-      "```javascript test",
-      "1 + 1 //=> 2",
-      "```",
-    ].join("\n");
+      '# Hello',
+      '',
+      '```javascript test',
+      '1 + 1 //=> 2',
+      '```',
+    ].join('\n');
 
     const { blocks, hasTypescript } = extractBlocks(md);
     assert.equal(blocks.length, 1);
-    assert.equal(blocks[0].code, "1 + 1 //=> 2\n");
-    assert.equal(blocks[0].lang, "javascript");
-    assert.equal(blocks[0].tag, "test");
+    assert.equal(blocks[0].code, '1 + 1 //=> 2\n');
+    assert.equal(blocks[0].lang, 'javascript');
+    assert.equal(blocks[0].tag, 'test');
     assert.equal(blocks[0].startLine, 4);
     assert.equal(hasTypescript, false);
   });
 
   it("extracts 'should' tagged blocks", () => {
     const md = [
-      "```javascript should equal 1",
-      "let a = 1;",
-      "a; //=> 1",
-      "```",
-    ].join("\n");
+      '```javascript should equal 1',
+      'let a = 1;',
+      'a; //=> 1',
+      '```',
+    ].join('\n');
 
     const { blocks } = extractBlocks(md);
     assert.equal(blocks.length, 1);
-    assert.equal(blocks[0].tag, "should equal 1");
+    assert.equal(blocks[0].tag, 'should equal 1');
   });
 
-  it("skips untagged blocks in default mode", () => {
+  it('skips untagged blocks in default mode', () => {
     const md = [
-      "```javascript",
-      "const x = 1;",
-      "```",
-      "",
-      "```javascript test",
-      "x; //=> 1",
-      "```",
-    ].join("\n");
+      '```javascript',
+      'const x = 1;',
+      '```',
+      '',
+      '```javascript test',
+      'x; //=> 1',
+      '```',
+    ].join('\n');
 
     const { blocks } = extractBlocks(md);
     assert.equal(blocks.length, 1);
-    assert.ok(blocks[0].code.includes("//=> 1"));
+    assert.ok(blocks[0].code.includes('//=> 1'));
   });
 
-  it("auto mode detects assertion comments", () => {
+  it('auto mode detects assertion comments', () => {
     const md = [
-      "```javascript",
-      "1 + 1 //=> 2",
-      "```",
-      "",
-      "```javascript",
-      "const x = 1;",
-      "```",
-    ].join("\n");
+      '```javascript',
+      '1 + 1 //=> 2',
+      '```',
+      '',
+      '```javascript',
+      'const x = 1;',
+      '```',
+    ].join('\n');
 
     const { blocks } = extractBlocks(md, { auto: true });
     assert.equal(blocks.length, 1);
-    assert.ok(blocks[0].code.includes("//=> 2"));
+    assert.ok(blocks[0].code.includes('//=> 2'));
   });
 
-  it("auto mode detects utf-8 arrow", () => {
-    const md = [
-      "```javascript",
-      "1 + 1 // → 2",
-      "```",
-    ].join("\n");
+  it('auto mode detects utf-8 arrow', () => {
+    const md = ['```javascript', '1 + 1 // → 2', '```'].join('\n');
 
     const { blocks } = extractBlocks(md, { auto: true });
     assert.equal(blocks.length, 1);
   });
 
-  it("auto mode detects ascii arrow", () => {
-    const md = [
-      "```javascript",
-      "1 + 1 // -> 2",
-      "```",
-    ].join("\n");
+  it('auto mode detects ascii arrow', () => {
+    const md = ['```javascript', '1 + 1 // -> 2', '```'].join('\n');
 
     const { blocks } = extractBlocks(md, { auto: true });
     assert.equal(blocks.length, 1);
   });
 
-  it("auto mode detects throws", () => {
-    const md = [
-      "```javascript",
-      "fn() // throws /err/",
-      "```",
-    ].join("\n");
+  it('auto mode detects throws', () => {
+    const md = ['```javascript', 'fn() // throws /err/', '```'].join('\n');
 
     const { blocks } = extractBlocks(md, { auto: true });
     assert.equal(blocks.length, 1);
   });
 
-  it("auto mode detects rejects", () => {
-    const md = [
-      "```javascript",
-      "fn() // rejects /err/",
-      "```",
-    ].join("\n");
+  it('auto mode detects rejects', () => {
+    const md = ['```javascript', 'fn() // rejects /err/', '```'].join('\n');
 
     const { blocks } = extractBlocks(md, { auto: true });
     assert.equal(blocks.length, 1);
   });
 
-  it("all mode includes every JS/TS block", () => {
+  it('all mode includes every JS/TS block', () => {
     const md = [
-      "```javascript",
-      "const x = 1;",
-      "```",
-      "",
-      "```python",
-      "x = 1",
-      "```",
-      "",
-      "```typescript",
-      "const y: number = 2;",
-      "```",
-    ].join("\n");
+      '```javascript',
+      'const x = 1;',
+      '```',
+      '',
+      '```python',
+      'x = 1',
+      '```',
+      '',
+      '```typescript',
+      'const y: number = 2;',
+      '```',
+    ].join('\n');
 
     const { blocks, hasTypescript } = extractBlocks(md, { all: true });
     assert.equal(blocks.length, 2);
-    assert.equal(blocks[0].lang, "javascript");
-    assert.equal(blocks[1].lang, "typescript");
+    assert.equal(blocks[0].lang, 'javascript');
+    assert.equal(blocks[1].lang, 'typescript');
     assert.equal(hasTypescript, true);
   });
 
-  it("tracks correct startLine across multiple blocks", () => {
+  it('tracks correct startLine across multiple blocks', () => {
     const md = [
-      "# Title",           // 1
-      "",                   // 2
-      "Some text.",         // 3
-      "",                   // 4
-      "```javascript test", // 5
-      "let a = 1;",        // 6
-      "```",               // 7
-      "",                   // 8
-      "```javascript test", // 9
-      "let b = 2;",        // 10
-      "```",               // 11
-    ].join("\n");
+      '# Title', // 1
+      '', // 2
+      'Some text.', // 3
+      '', // 4
+      '```javascript test', // 5
+      'let a = 1;', // 6
+      '```', // 7
+      '', // 8
+      '```javascript test', // 9
+      'let b = 2;', // 10
+      '```', // 11
+    ].join('\n');
 
     const { blocks } = extractBlocks(md);
     assert.equal(blocks.length, 2);
@@ -153,66 +137,58 @@ describe("extractBlocks", () => {
     assert.equal(blocks[1].startLine, 10);
   });
 
-  it("handles ts and js shorthand langs", () => {
+  it('handles ts and js shorthand langs', () => {
     const md = [
-      "```ts test",
-      "const x: number = 1;",
-      "```",
-      "",
-      "```js test",
-      "const y = 2;",
-      "```",
-    ].join("\n");
+      '```ts test',
+      'const x: number = 1;',
+      '```',
+      '',
+      '```js test',
+      'const y = 2;',
+      '```',
+    ].join('\n');
 
     const { blocks, hasTypescript } = extractBlocks(md);
     assert.equal(blocks.length, 2);
-    assert.equal(blocks[0].lang, "ts");
-    assert.equal(blocks[1].lang, "js");
+    assert.equal(blocks[0].lang, 'ts');
+    assert.equal(blocks[1].lang, 'js');
     assert.equal(hasTypescript, true);
   });
 
-  it("returns empty blocks array when no matches", () => {
-    const md = "# Just a title\n\nSome text.";
+  it('returns empty blocks array when no matches', () => {
+    const md = '# Just a title\n\nSome text.';
     const { blocks } = extractBlocks(md);
     assert.equal(blocks.length, 0);
   });
 
-  it("parses group from test:groupname tag", () => {
+  it('parses group from test:groupname tag', () => {
     const md = [
-      "```javascript test:mygroup",
-      "let x = 1;",
-      "```",
-      "",
-      "```javascript test:mygroup",
-      "x; //=> 1",
-      "```",
-    ].join("\n");
+      '```javascript test:mygroup',
+      'let x = 1;',
+      '```',
+      '',
+      '```javascript test:mygroup',
+      'x; //=> 1',
+      '```',
+    ].join('\n');
 
     const { blocks } = extractBlocks(md);
     assert.equal(blocks.length, 2);
-    assert.equal(blocks[0].group, "mygroup");
-    assert.equal(blocks[1].group, "mygroup");
+    assert.equal(blocks[0].group, 'mygroup');
+    assert.equal(blocks[1].group, 'mygroup');
   });
 
-  it("ungrouped blocks have null group", () => {
-    const md = [
-      "```javascript test",
-      "1; //=> 1",
-      "```",
-    ].join("\n");
+  it('ungrouped blocks have null group', () => {
+    const md = ['```javascript test', '1; //=> 1', '```'].join('\n');
 
     const { blocks } = extractBlocks(md);
     assert.equal(blocks[0].group, null);
   });
 
-  it("parses group from should:groupname tag", () => {
-    const md = [
-      "```javascript should:g1 work",
-      "1; //=> 1",
-      "```",
-    ].join("\n");
+  it('parses group from should:groupname tag', () => {
+    const md = ['```javascript should:g1 work', '1; //=> 1', '```'].join('\n');
 
     const { blocks } = extractBlocks(md);
-    assert.equal(blocks[0].group, "g1");
+    assert.equal(blocks[0].group, 'g1');
   });
 });

--- a/test/fixtures/pkg-no-exports/lib/index.js
+++ b/test/fixtures/pkg-no-exports/lib/index.js
@@ -1,1 +1,1 @@
-export const main = () => "main";
+export const main = () => 'main';

--- a/test/fixtures/pkg-no-exports/lib/utils.js
+++ b/test/fixtures/pkg-no-exports/lib/utils.js
@@ -1,1 +1,1 @@
-export const helper = () => "help";
+export const helper = () => 'help';

--- a/test/fixtures/pkg-no-exports/readme.md
+++ b/test/fixtures/pkg-no-exports/readme.md
@@ -1,11 +1,11 @@
 # no-exports fixture
 
 ```javascript test
-import { main } from "@fixture/no-exports";
+import { main } from '@fixture/no-exports';
 main(); //=> "main"
 ```
 
 ```javascript test
-import { helper } from "@fixture/no-exports/lib/utils.js";
+import { helper } from '@fixture/no-exports/lib/utils.js';
 helper(); //=> "help"
 ```

--- a/test/fixtures/pkg-string-exports/lib/main.js
+++ b/test/fixtures/pkg-string-exports/lib/main.js
@@ -1,1 +1,1 @@
-export const hello = () => "world";
+export const hello = () => 'world';

--- a/test/fixtures/pkg-string-exports/readme.md
+++ b/test/fixtures/pkg-string-exports/readme.md
@@ -1,6 +1,6 @@
 # string-exports fixture
 
 ```javascript test
-import { hello } from "@fixture/string-exports";
+import { hello } from '@fixture/string-exports';
 hello(); //=> "world"
 ```

--- a/test/fixtures/pkg-subpath-exports/readme.md
+++ b/test/fixtures/pkg-subpath-exports/readme.md
@@ -1,11 +1,11 @@
 # subpath-exports fixture
 
 ```javascript test
-import { main } from "@fixture/subpath-exports";
+import { main } from '@fixture/subpath-exports';
 main(); //=> "main"
 ```
 
 ```javascript test
-import { helper } from "@fixture/subpath-exports/utils";
+import { helper } from '@fixture/subpath-exports/utils';
 helper(); //=> "help"
 ```

--- a/test/fixtures/pkg-subpath-exports/src/index.js
+++ b/test/fixtures/pkg-subpath-exports/src/index.js
@@ -1,1 +1,1 @@
-export const main = () => "main";
+export const main = () => 'main';

--- a/test/fixtures/pkg-subpath-exports/src/utils.js
+++ b/test/fixtures/pkg-subpath-exports/src/utils.js
@@ -1,1 +1,1 @@
-export const helper = () => "help";
+export const helper = () => 'help';

--- a/test/fixtures/require-downgrade/setup.cjs
+++ b/test/fixtures/require-downgrade/setup.cjs
@@ -1,1 +1,1 @@
-global.myGlobal = "hello from setup";
+global.myGlobal = 'hello from setup';

--- a/test/fixtures/stream-delay.md
+++ b/test/fixtures/stream-delay.md
@@ -5,7 +5,7 @@ marker should appear in `process.stdout` well before the block's
 delay elapses.
 
 ```javascript test
-console.log("STREAM-MARKER");
+console.log('STREAM-MARKER');
 await new Promise((r) => setTimeout(r, 500));
 1; //=> 1
 ```

--- a/test/fixtures/throws.md
+++ b/test/fixtures/throws.md
@@ -2,7 +2,7 @@
 
 ```javascript test
 const b = () => {
-  throw new Error("fail");
+  throw new Error('fail');
 };
 b(); // throws /fail/
 ```

--- a/test/fixtures/typescript.md
+++ b/test/fixtures/typescript.md
@@ -2,7 +2,7 @@
 
 ```typescript test
 const a: number = 1 + 1;
-const label: string = "two";
+const label: string = 'two';
 a; //=> 2
 label; //=> "two"
 ```

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -1,70 +1,126 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { generate } from "../src/generate.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generate } from '../src/generate.js';
 
-describe("generate", () => {
-  it("produces one unit per ungrouped block", () => {
+describe('generate', () => {
+  it('produces one unit per ungrouped block', () => {
     const { units } = generate({
       blocks: [
-        { code: "a; //=> 1\n", lang: "javascript", tag: "test", group: null, startLine: 3, endLine: 3 },
-        { code: "b; //=> 2\n", lang: "javascript", tag: "test", group: null, startLine: 7, endLine: 7 },
+        {
+          code: 'a; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test',
+          group: null,
+          startLine: 3,
+          endLine: 3,
+        },
+        {
+          code: 'b; //=> 2\n',
+          lang: 'javascript',
+          tag: 'test',
+          group: null,
+          startLine: 7,
+          endLine: 7,
+        },
       ],
       hasTypescript: false,
     });
     assert.equal(units.length, 2);
-    assert.ok(units[0].code.includes("a; //=> 1"));
-    assert.ok(!units[0].code.includes("b; //=> 2"));
-    assert.ok(units[1].code.includes("b; //=> 2"));
+    assert.ok(units[0].code.includes('a; //=> 1'));
+    assert.ok(!units[0].code.includes('b; //=> 2'));
+    assert.ok(units[1].code.includes('b; //=> 2'));
   });
 
-  it("merges blocks with the same group", () => {
+  it('merges blocks with the same group', () => {
     const { units } = generate({
       blocks: [
-        { code: "let x = 1;\n", lang: "javascript", tag: "test:math", group: "math", startLine: 3, endLine: 3 },
-        { code: "x; //=> 1\n", lang: "javascript", tag: "test:math", group: "math", startLine: 7, endLine: 7 },
+        {
+          code: 'let x = 1;\n',
+          lang: 'javascript',
+          tag: 'test:math',
+          group: 'math',
+          startLine: 3,
+          endLine: 3,
+        },
+        {
+          code: 'x; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test:math',
+          group: 'math',
+          startLine: 7,
+          endLine: 7,
+        },
       ],
       hasTypescript: false,
     });
     assert.equal(units.length, 1);
-    assert.ok(units[0].code.includes("let x = 1;"));
-    assert.ok(units[0].code.includes("x; //=> 1"));
-    assert.equal(units[0].name, "math");
+    assert.ok(units[0].code.includes('let x = 1;'));
+    assert.ok(units[0].code.includes('x; //=> 1'));
+    assert.equal(units[0].name, 'math');
   });
 
-  it("keeps grouped and ungrouped blocks separate", () => {
+  it('keeps grouped and ungrouped blocks separate', () => {
     const { units } = generate({
       blocks: [
-        { code: "a; //=> 1\n", lang: "javascript", tag: "test", group: null, startLine: 3, endLine: 3 },
-        { code: "let x = 1;\n", lang: "javascript", tag: "test:g1", group: "g1", startLine: 7, endLine: 7 },
-        { code: "x; //=> 1\n", lang: "javascript", tag: "test:g1", group: "g1", startLine: 11, endLine: 11 },
+        {
+          code: 'a; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test',
+          group: null,
+          startLine: 3,
+          endLine: 3,
+        },
+        {
+          code: 'let x = 1;\n',
+          lang: 'javascript',
+          tag: 'test:g1',
+          group: 'g1',
+          startLine: 7,
+          endLine: 7,
+        },
+        {
+          code: 'x; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test:g1',
+          group: 'g1',
+          startLine: 11,
+          endLine: 11,
+        },
       ],
       hasTypescript: false,
     });
     assert.equal(units.length, 2);
-    assert.ok(units[0].code.includes("a; //=> 1"));
-    assert.ok(units[1].code.includes("let x = 1;"));
-    assert.ok(units[1].code.includes("x; //=> 1"));
+    assert.ok(units[0].code.includes('a; //=> 1'));
+    assert.ok(units[1].code.includes('let x = 1;'));
+    assert.ok(units[1].code.includes('x; //=> 1'));
   });
 
-  it("places code at original line positions", () => {
+  it('places code at original line positions', () => {
     const { units } = generate({
       blocks: [
-        { code: "a; //=> 1\n", lang: "javascript", tag: "test", group: null, startLine: 3, endLine: 3 },
+        {
+          code: 'a; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test',
+          group: null,
+          startLine: 3,
+          endLine: 3,
+        },
       ],
       hasTypescript: false,
     });
-    const lines = units[0].code.split("\n");
-    assert.equal(lines[2], "a; //=> 1");
-    assert.equal(lines[0], "");
+    const lines = units[0].code.split('\n');
+    assert.equal(lines[2], 'a; //=> 1');
+    assert.equal(lines[0], '');
   });
 
-  it("preserves import positions in assembled code", () => {
+  it('preserves import positions in assembled code', () => {
     const { units } = generate({
       blocks: [
         {
           code: 'import { foo } from "bar";\nfoo() //=> 42\n',
-          lang: "javascript",
-          tag: "test",
+          lang: 'javascript',
+          tag: 'test',
           group: null,
           startLine: 3,
           endLine: 4,
@@ -72,24 +128,38 @@ describe("generate", () => {
       ],
       hasTypescript: false,
     });
-    const lines = units[0].code.split("\n");
+    const lines = units[0].code.split('\n');
     const importLine = lines.findIndex((l) => l.includes('from "bar"'));
-    const bodyLine = lines.findIndex((l) => l.includes("foo()"));
+    const bodyLine = lines.findIndex((l) => l.includes('foo()'));
     assert.ok(importLine < bodyLine);
     // Import stays at its original position (not hoisted — transform does that)
     assert.equal(importLine, 2); // startLine 3 → index 2
   });
 
-  it("returns empty units for no blocks", () => {
+  it('returns empty units for no blocks', () => {
     const { units } = generate({ blocks: [], hasTypescript: false });
     assert.equal(units.length, 0);
   });
 
-  it("tracks typescript per unit", () => {
+  it('tracks typescript per unit', () => {
     const { units } = generate({
       blocks: [
-        { code: "a; //=> 1\n", lang: "javascript", tag: "test", group: null, startLine: 3, endLine: 3 },
-        { code: "const x: number = 1;\n", lang: "typescript", tag: "test", group: null, startLine: 7, endLine: 7 },
+        {
+          code: 'a; //=> 1\n',
+          lang: 'javascript',
+          tag: 'test',
+          group: null,
+          startLine: 3,
+          endLine: 3,
+        },
+        {
+          code: 'const x: number = 1;\n',
+          lang: 'typescript',
+          tag: 'test',
+          group: null,
+          startLine: 7,
+          endLine: 7,
+        },
       ],
       hasTypescript: true,
     });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,8 +1,8 @@
-import assert from "node:assert/strict";
-import { parseSync } from "oxc-parser";
+import assert from 'node:assert/strict';
+import { parseSync } from 'oxc-parser';
 
 export function parse(code) {
-  return parseSync("t.js", code).program;
+  return parseSync('t.js', code).program;
 }
 
 export function methodName(call) {
@@ -11,28 +11,29 @@ export function methodName(call) {
 
 export function assertCall(code) {
   const body = parse(code).body;
-  const stmt = body.find((n) => n.type === "ExpressionStatement");
-  const expr = stmt?.expression?.type === "AwaitExpression"
-    ? stmt.expression.argument
-    : stmt?.expression;
-  assert.equal(expr?.type, "CallExpression");
+  const stmt = body.find((n) => n.type === 'ExpressionStatement');
+  const expr =
+    stmt?.expression?.type === 'AwaitExpression'
+      ? stmt.expression.argument
+      : stmt?.expression;
+  assert.equal(expr?.type, 'CallExpression');
   return expr;
 }
 
 export function assertAwaitedCall(code) {
-  const stmt = parse(code).body.find((n) => n.type === "ExpressionStatement");
-  assert.equal(stmt.expression.type, "AwaitExpression");
+  const stmt = parse(code).body.find((n) => n.type === 'ExpressionStatement');
+  assert.equal(stmt.expression.type, 'AwaitExpression');
   const call = stmt.expression.argument;
-  assert.equal(call.type, "CallExpression");
+  assert.equal(call.type, 'CallExpression');
   return call;
 }
 
 export function assembled(startLine, code) {
-  const codeLines = code.replace(/\n$/, "").split("\n");
+  const codeLines = code.replace(/\n$/, '').split('\n');
   const maxLine = startLine + codeLines.length - 1;
-  const lines = new Array(maxLine).fill("");
+  const lines = new Array(maxLine).fill('');
   for (let i = 0; i < codeLines.length; i++) {
     lines[startLine - 1 + i] = codeLines[i];
   }
-  return lines.join("\n") + "\n";
+  return lines.join('\n') + '\n';
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,37 +1,37 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
-import { spawn, spawnSync } from "node:child_process";
-import { processMarkdown, run } from "../src/run.js";
-import { resolveMainEntry, resolveSubpathExport } from "../src/resolve.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { processMarkdown, run } from '../src/run.js';
+import { resolveMainEntry, resolveSubpathExport } from '../src/resolve.js';
 
-const repoRoot = new URL("../", import.meta.url).pathname;
+const repoRoot = new URL('../', import.meta.url).pathname;
 
-const cliPath = new URL("../src/cli.js", import.meta.url).pathname;
+const cliPath = new URL('../src/cli.js', import.meta.url).pathname;
 
-const fixturesDir = new URL("./fixtures/", import.meta.url).pathname;
+const fixturesDir = new URL('./fixtures/', import.meta.url).pathname;
 
-describe("processMarkdown", () => {
-  it("transforms simple.md into separate units", async () => {
-    const units = await processMarkdown(path.join(fixturesDir, "simple.md"));
+describe('processMarkdown', () => {
+  it('transforms simple.md into separate units', async () => {
+    const units = await processMarkdown(path.join(fixturesDir, 'simple.md'));
     assert.ok(units.length >= 1);
-    const allCode = units.map((u) => u.code).join("\n");
-    assert.ok(allCode.includes("assert.deepEqual(a, 1);"));
-    assert.ok(allCode.includes("assert.deepEqual(b, 2);"));
+    const allCode = units.map((u) => u.code).join('\n');
+    assert.ok(allCode.includes('assert.deepEqual(a, 1);'));
+    assert.ok(allCode.includes('assert.deepEqual(b, 2);'));
   });
 
-  it("transforms throws.md", async () => {
-    const units = await processMarkdown(path.join(fixturesDir, "throws.md"));
+  it('transforms throws.md', async () => {
+    const units = await processMarkdown(path.join(fixturesDir, 'throws.md'));
     assert.ok(units.length >= 1);
-    assert.ok(units[0].code.includes("assert.throws("));
+    assert.ok(units[0].code.includes('assert.throws('));
   });
 
-  it("rewrites imports when package.json exports is a string", async () => {
-    const readme = path.join(fixturesDir, "pkg-string-exports/readme.md");
-    const expected = path.join(fixturesDir, "pkg-string-exports/lib/main.js");
+  it('rewrites imports when package.json exports is a string', async () => {
+    const readme = path.join(fixturesDir, 'pkg-string-exports/readme.md');
+    const expected = path.join(fixturesDir, 'pkg-string-exports/lib/main.js');
     const units = await processMarkdown(readme);
-    const code = units.map((u) => u.code).join("\n");
+    const code = units.map((u) => u.code).join('\n');
     assert.ok(
       code.includes(expected),
       `expected import rewritten to ${expected}, got:\n${code}`,
@@ -39,14 +39,11 @@ describe("processMarkdown", () => {
     assert.ok(!code.includes('"@fixture/string-exports"'));
   });
 
-  it("rewrites subpath imports via exports map", async () => {
-    const readme = path.join(fixturesDir, "pkg-subpath-exports/readme.md");
-    const expected = path.join(
-      fixturesDir,
-      "pkg-subpath-exports/src/utils.js",
-    );
+  it('rewrites subpath imports via exports map', async () => {
+    const readme = path.join(fixturesDir, 'pkg-subpath-exports/readme.md');
+    const expected = path.join(fixturesDir, 'pkg-subpath-exports/src/utils.js');
     const units = await processMarkdown(readme);
-    const code = units.map((u) => u.code).join("\n");
+    const code = units.map((u) => u.code).join('\n');
     assert.ok(
       code.includes(expected),
       `expected subpath import rewritten to ${expected}, got:\n${code}`,
@@ -54,50 +51,55 @@ describe("processMarkdown", () => {
     assert.ok(!code.includes('"@fixture/subpath-exports/utils"'));
   });
 
-  it("falls back to package root when no exports map", async () => {
-    const readme = path.join(fixturesDir, "pkg-no-exports/readme.md");
-    const expected = path.join(
-      fixturesDir,
-      "pkg-no-exports/lib/utils.js",
-    );
+  it('falls back to package root when no exports map', async () => {
+    const readme = path.join(fixturesDir, 'pkg-no-exports/readme.md');
+    const expected = path.join(fixturesDir, 'pkg-no-exports/lib/utils.js');
     const units = await processMarkdown(readme);
-    const code = units.map((u) => u.code).join("\n");
+    const code = units.map((u) => u.code).join('\n');
     assert.ok(
       code.includes(expected),
       `expected subpath rewritten to ${expected}, got:\n${code}`,
     );
   });
 
-  it("throws NO_TEST_BLOCKS when the readme has no test blocks", async () => {
+  it('throws NO_TEST_BLOCKS when the readme has no test blocks', async () => {
     await assert.rejects(
-      () => processMarkdown(path.join(fixturesDir, "no-blocks.md")),
+      () => processMarkdown(path.join(fixturesDir, 'no-blocks.md')),
       (err) => {
-        assert.equal(err.code, "NO_TEST_BLOCKS");
+        assert.equal(err.code, 'NO_TEST_BLOCKS');
         assert.match(err.message, /no-blocks\.md/);
         return true;
       },
     );
   });
 
-  it("strips TypeScript types via esbuild for ts blocks", async () => {
-    const units = await processMarkdown(path.join(fixturesDir, "typescript.md"));
+  it('strips TypeScript types via esbuild for ts blocks', async () => {
+    const units = await processMarkdown(
+      path.join(fixturesDir, 'typescript.md'),
+    );
     assert.equal(units.length, 1);
     const code = units[0].code;
     // esbuild should have removed the TS type annotations
-    assert.ok(!code.includes(": number"), `expected no ": number" in:\n${code}`);
-    assert.ok(!code.includes(": string"), `expected no ": string" in:\n${code}`);
+    assert.ok(
+      !code.includes(': number'),
+      `expected no ": number" in:\n${code}`,
+    );
+    assert.ok(
+      !code.includes(': string'),
+      `expected no ": string" in:\n${code}`,
+    );
     // The assert calls should still be there
-    assert.ok(code.includes("assert.deepEqual(a, 2);"));
+    assert.ok(code.includes('assert.deepEqual(a, 2);'));
     assert.ok(code.includes('assert.deepEqual(label, "two");'));
   });
 });
 
-describe("cli", () => {
-  it("exits cleanly when the readme has no test blocks", () => {
+describe('cli', () => {
+  it('exits cleanly when the readme has no test blocks', () => {
     const result = spawnSync(
-      "node",
-      [cliPath, "-f", path.join(fixturesDir, "no-blocks.md")],
-      { encoding: "utf-8" },
+      'node',
+      [cliPath, '-f', path.join(fixturesDir, 'no-blocks.md')],
+      { encoding: 'utf-8' },
     );
     assert.equal(result.status, 1);
     assert.match(result.stderr, /No test code blocks found/);
@@ -106,9 +108,9 @@ describe("cli", () => {
     assert.doesNotMatch(result.stderr, /\bNode\.js v/);
   });
 
-  it("rejects unknown flags with a friendly message", () => {
-    const result = spawnSync("node", [cliPath, "--autop"], {
-      encoding: "utf-8",
+  it('rejects unknown flags with a friendly message', () => {
+    const result = spawnSync('node', [cliPath, '--autop'], {
+      encoding: 'utf-8',
     });
     assert.equal(result.status, 1);
     assert.match(result.stderr, /autop/);
@@ -117,24 +119,24 @@ describe("cli", () => {
     assert.doesNotMatch(result.stderr, /at parseArgs/);
   });
 
-  it("streams stdout live instead of buffering until the block finishes", async () => {
+  it('streams stdout live instead of buffering until the block finishes', async () => {
     // stream-delay.md prints "STREAM-MARKER", sleeps 500ms, then asserts.
     // With streaming, the marker should arrive well before the child exits.
-    const readme = path.join(fixturesDir, "stream-delay.md");
-    const child = spawn("node", [cliPath, "-f", readme]);
+    const readme = path.join(fixturesDir, 'stream-delay.md');
+    const child = spawn('node', [cliPath, '-f', readme]);
     const start = Date.now();
     let markerAt = null;
-    child.stdout.on("data", (chunk) => {
-      if (markerAt === null && chunk.toString().includes("STREAM-MARKER")) {
+    child.stdout.on('data', (chunk) => {
+      if (markerAt === null && chunk.toString().includes('STREAM-MARKER')) {
         markerAt = Date.now() - start;
       }
     });
     const exitCode = await new Promise((resolve) => {
-      child.on("exit", resolve);
+      child.on('exit', resolve);
     });
     const total = Date.now() - start;
     assert.equal(exitCode, 0);
-    assert.ok(markerAt !== null, "STREAM-MARKER never appeared in stdout");
+    assert.ok(markerAt !== null, 'STREAM-MARKER never appeared in stdout');
     // The block sleeps 500ms after printing; if we're streaming, the
     // marker should arrive at least 200ms before the child exits.
     assert.ok(
@@ -144,190 +146,184 @@ describe("cli", () => {
   });
 });
 
-describe("skill docs", () => {
-  it("keeps docs/skill.md in sync with .claude/skills/readme-assert.md", () => {
+describe('skill docs', () => {
+  it('keeps docs/skill.md in sync with .claude/skills/readme-assert.md', () => {
     const skill = fs.readFileSync(
-      path.join(repoRoot, ".claude/skills/readme-assert.md"),
-      "utf-8",
+      path.join(repoRoot, '.claude/skills/readme-assert.md'),
+      'utf-8',
     );
-    const docs = fs.readFileSync(
-      path.join(repoRoot, "docs/skill.md"),
-      "utf-8",
-    );
+    const docs = fs.readFileSync(path.join(repoRoot, 'docs/skill.md'), 'utf-8');
     // The docs page wraps the skill in a ```` markdown fence; extract it
     // and verify byte-for-byte equality with the source-of-truth skill.
     const match = docs.match(/^````markdown\n([\s\S]+?)\n````$/m);
-    assert.ok(
-      match,
-      "expected docs/skill.md to contain a ```` markdown fence",
-    );
+    assert.ok(match, 'expected docs/skill.md to contain a ```` markdown fence');
     assert.equal(
       match[1],
-      skill.replace(/\n$/, ""),
-      "docs/skill.md code block is out of sync with .claude/skills/readme-assert.md",
+      skill.replace(/\n$/, ''),
+      'docs/skill.md code block is out of sync with .claude/skills/readme-assert.md',
     );
   });
 });
 
-describe("run", () => {
-  it("executes simple.md successfully", async () => {
-    const result = await run(path.join(fixturesDir, "simple.md"));
+describe('run', () => {
+  it('executes simple.md successfully', async () => {
+    const result = await run(path.join(fixturesDir, 'simple.md'));
     assert.equal(result.exitCode, 0);
   });
 
-  it("executes throws.md successfully", async () => {
-    const result = await run(path.join(fixturesDir, "throws.md"));
+  it('executes throws.md successfully', async () => {
+    const result = await run(path.join(fixturesDir, 'throws.md'));
     assert.equal(result.exitCode, 0);
   });
 
-  it("executes a package with exports as string", async () => {
+  it('executes a package with exports as string', async () => {
     const result = await run(
-      path.join(fixturesDir, "pkg-string-exports/readme.md"),
+      path.join(fixturesDir, 'pkg-string-exports/readme.md'),
     );
     assert.equal(result.exitCode, 0, result.stderr);
   });
 
-  it("executes a package with subpath exports", async () => {
+  it('executes a package with subpath exports', async () => {
     const result = await run(
-      path.join(fixturesDir, "pkg-subpath-exports/readme.md"),
+      path.join(fixturesDir, 'pkg-subpath-exports/readme.md'),
     );
     assert.equal(result.exitCode, 0, result.stderr);
   });
 
-  it("executes subpath imports without exports map (dirname fallback)", async () => {
+  it('executes subpath imports without exports map (dirname fallback)', async () => {
     const result = await run(
-      path.join(fixturesDir, "pkg-no-exports/readme.md"),
+      path.join(fixturesDir, 'pkg-no-exports/readme.md'),
     );
     assert.equal(result.exitCode, 0, result.stderr);
   });
 
-  it("reports the correct line when a block contains a console.log assertion", async () => {
+  it('reports the correct line when a block contains a console.log assertion', async () => {
     // The failing expression `b; //=> 3` is on line 6 of console-shift.md.
     // Regression: the console.log transform used to insert a newline which
     // shifted later lines, pointing the error at the closing fence.
-    const result = await run(path.join(fixturesDir, "console-shift.md"));
+    const result = await run(path.join(fixturesDir, 'console-shift.md'));
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stderr, /console-shift\.md:6/);
   });
 
-  it("executes a TypeScript block end-to-end", async () => {
-    const result = await run(path.join(fixturesDir, "typescript.md"));
+  it('executes a TypeScript block end-to-end', async () => {
+    const result = await run(path.join(fixturesDir, 'typescript.md'));
     assert.equal(result.exitCode, 0, result.stderr);
   });
 
-  it("downgrades plain blocks to CJS so --require hooks apply", async () => {
+  it('downgrades plain blocks to CJS so --require hooks apply', async () => {
     // Plain code (no import/export/require) + --require should produce a
     // .cjs tmp file so the setup script's globals are visible to the block.
-    const readme = path.join(fixturesDir, "require-downgrade/readme.md");
-    const setup = path.join(fixturesDir, "require-downgrade/setup.cjs");
+    const readme = path.join(fixturesDir, 'require-downgrade/readme.md');
+    const setup = path.join(fixturesDir, 'require-downgrade/setup.cjs');
     const result = await run(readme, { require: [setup] });
     assert.equal(result.exitCode, 0, result.stderr);
   });
 });
 
-describe("resolveMainEntry", () => {
-  it("returns pkg.main when set", () => {
-    assert.equal(resolveMainEntry({ main: "./foo.js" }), "./foo.js");
+describe('resolveMainEntry', () => {
+  it('returns pkg.main when set', () => {
+    assert.equal(resolveMainEntry({ main: './foo.js' }), './foo.js');
   });
 
-  it("pkg.main takes precedence over exports", () => {
+  it('pkg.main takes precedence over exports', () => {
     assert.equal(
-      resolveMainEntry({ main: "./foo.js", exports: "./bar.js" }),
-      "./foo.js",
+      resolveMainEntry({ main: './foo.js', exports: './bar.js' }),
+      './foo.js',
     );
   });
 
-  it("returns exports when it is a string", () => {
+  it('returns exports when it is a string', () => {
     assert.equal(
-      resolveMainEntry({ exports: "./lib/main.js" }),
-      "./lib/main.js",
+      resolveMainEntry({ exports: './lib/main.js' }),
+      './lib/main.js',
     );
   });
 
   it("returns exports['.'] when it is a subpath map", () => {
     assert.equal(
       resolveMainEntry({
-        exports: { ".": "./lib/main.js", "./sub": "./sub.js" },
+        exports: { '.': './lib/main.js', './sub': './sub.js' },
       }),
-      "./lib/main.js",
+      './lib/main.js',
     );
   });
 
-  it("resolves conditional exports at a subpath", () => {
+  it('resolves conditional exports at a subpath', () => {
     assert.equal(
       resolveMainEntry({
-        exports: { ".": { import: "./esm.js", require: "./cjs.js" } },
+        exports: { '.': { import: './esm.js', require: './cjs.js' } },
       }),
-      "./esm.js",
+      './esm.js',
     );
   });
 
-  it("resolves bare conditional exports (no subpaths)", () => {
+  it('resolves bare conditional exports (no subpaths)', () => {
     assert.equal(
       resolveMainEntry({
-        exports: { import: "./esm.js", require: "./cjs.js" },
+        exports: { import: './esm.js', require: './cjs.js' },
       }),
-      "./esm.js",
+      './esm.js',
     );
   });
 
-  it("prefers import > default > require", () => {
+  it('prefers import > default > require', () => {
     assert.equal(
       resolveMainEntry({
-        exports: { require: "./cjs.js", default: "./default.js" },
+        exports: { require: './cjs.js', default: './default.js' },
       }),
-      "./default.js",
+      './default.js',
     );
     assert.equal(
-      resolveMainEntry({ exports: { require: "./cjs.js" } }),
-      "./cjs.js",
+      resolveMainEntry({ exports: { require: './cjs.js' } }),
+      './cjs.js',
     );
   });
 
-  it("resolves nested conditions", () => {
+  it('resolves nested conditions', () => {
     assert.equal(
       resolveMainEntry({
         exports: {
-          ".": {
-            import: { types: "./types.d.ts", default: "./esm.js" },
+          '.': {
+            import: { types: './types.d.ts', default: './esm.js' },
           },
         },
       }),
-      "./esm.js",
+      './esm.js',
     );
   });
 
-  it("returns null when no entry can be determined", () => {
+  it('returns null when no entry can be determined', () => {
     assert.equal(resolveMainEntry({}), null);
     assert.equal(resolveMainEntry({ exports: null }), null);
   });
 });
 
-describe("resolveSubpathExport", () => {
-  it("returns null for string exports", () => {
-    assert.equal(resolveSubpathExport("./index.js", "./utils"), null);
+describe('resolveSubpathExport', () => {
+  it('returns null for string exports', () => {
+    assert.equal(resolveSubpathExport('./index.js', './utils'), null);
   });
 
-  it("resolves a direct subpath", () => {
-    const exp = { ".": "./src/index.js", "./utils": "./src/utils.js" };
-    assert.equal(resolveSubpathExport(exp, "./utils"), "./src/utils.js");
+  it('resolves a direct subpath', () => {
+    const exp = { '.': './src/index.js', './utils': './src/utils.js' };
+    assert.equal(resolveSubpathExport(exp, './utils'), './src/utils.js');
   });
 
-  it("resolves a conditional subpath", () => {
+  it('resolves a conditional subpath', () => {
     const exp = {
-      ".": "./src/index.js",
-      "./utils": { import: "./src/utils.mjs", require: "./src/utils.cjs" },
+      '.': './src/index.js',
+      './utils': { import: './src/utils.mjs', require: './src/utils.cjs' },
     };
-    assert.equal(resolveSubpathExport(exp, "./utils"), "./src/utils.mjs");
+    assert.equal(resolveSubpathExport(exp, './utils'), './src/utils.mjs');
   });
 
-  it("returns null when subpath is not in map", () => {
-    const exp = { ".": "./src/index.js" };
-    assert.equal(resolveSubpathExport(exp, "./missing"), null);
+  it('returns null when subpath is not in map', () => {
+    const exp = { '.': './src/index.js' };
+    assert.equal(resolveSubpathExport(exp, './missing'), null);
   });
 
-  it("returns null for bare conditional exports (no subpath keys)", () => {
-    const exp = { import: "./esm.js", require: "./cjs.js" };
-    assert.equal(resolveSubpathExport(exp, "./utils"), null);
+  it('returns null for bare conditional exports (no subpath keys)', () => {
+    const exp = { import: './esm.js', require: './cjs.js' };
+    assert.equal(resolveSubpathExport(exp, './utils'), null);
   });
 });

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -1,159 +1,202 @@
-import { describe, it } from "node:test";
-import assert from "node:assert/strict";
-import { transform } from "../src/transform.js";
-import { parse, methodName, assembled } from "./helpers.js";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { transform } from '../src/transform.js';
+import { parse, methodName, assembled } from './helpers.js';
 
 function findCalls(code) {
-  return parse(code).body
-    .filter((n) => n.type === "ExpressionStatement")
+  return parse(code)
+    .body.filter((n) => n.type === 'ExpressionStatement')
     .map((n) => {
       const e = n.expression;
-      return e.type === "AwaitExpression" ? e.argument : e;
+      return e.type === 'AwaitExpression' ? e.argument : e;
     })
-    .filter((e) => e?.type === "CallExpression");
+    .filter((e) => e?.type === 'CallExpression');
 }
 
 function findImports(code) {
-  return parse(code).body.filter((n) => n.type === "ImportDeclaration");
+  return parse(code).body.filter((n) => n.type === 'ImportDeclaration');
 }
 
-describe("transform – import hoisting", () => {
-  it("hoists ESM imports and adds assert import", () => {
-    const { code } = transform(assembled(3, 'import { foo } from "bar";\nfoo() //=> 42\n'), { hoistImports: true });
+describe('transform – import hoisting', () => {
+  it('hoists ESM imports and adds assert import', () => {
+    const { code } = transform(
+      assembled(3, 'import { foo } from "bar";\nfoo() //=> 42\n'),
+      { hoistImports: true },
+    );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === "node:assert/strict"));
-    assert.ok(imports.some((n) => n.source.value === "bar"));
+    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
+    assert.ok(imports.some((n) => n.source.value === 'bar'));
   });
 
-  it("uses CJS assert when body has require()", () => {
-    const { code } = transform(assembled(3, 'const x = require("foo");\nx; //=> 1\n'), { hoistImports: true });
+  it('uses CJS assert when body has require()', () => {
+    const { code } = transform(
+      assembled(3, 'const x = require("foo");\nx; //=> 1\n'),
+      { hoistImports: true },
+    );
     const body = parse(code).body;
-    const decl = body.find((n) => n.type === "VariableDeclaration");
+    const decl = body.find((n) => n.type === 'VariableDeclaration');
     assert.ok(decl);
-    assert.equal(decl.declarations[0].init.callee?.name, "require");
-    assert.equal(decl.declarations[0].init.arguments[0].value, "node:assert/strict");
+    assert.equal(decl.declarations[0].init.callee?.name, 'require');
+    assert.equal(
+      decl.declarations[0].init.arguments[0].value,
+      'node:assert/strict',
+    );
   });
 
-  it("uses dynamic import for plain code", () => {
-    const { code } = transform(assembled(3, "a; //=> 1\n"), { hoistImports: true });
+  it('uses dynamic import for plain code', () => {
+    const { code } = transform(assembled(3, 'a; //=> 1\n'), {
+      hoistImports: true,
+    });
     const body = parse(code).body;
-    const decl = body.find((n) => n.type === "VariableDeclaration");
+    const decl = body.find((n) => n.type === 'VariableDeclaration');
     assert.ok(decl);
     const init = decl.declarations[0].init;
     // Should be `await import(...)` — the init is an AwaitExpression wrapping an ImportExpression
-    assert.equal(init.type, "AwaitExpression");
-    assert.equal(init.argument.type, "ImportExpression");
+    assert.equal(init.type, 'AwaitExpression');
+    assert.equal(init.argument.type, 'ImportExpression');
   });
 
-  it("handles imports without semicolons", () => {
+  it('handles imports without semicolons', () => {
     const { code } = transform(
       assembled(3, 'import { a } from "x"\nimport { b } from "y"\na //=> 1\n'),
       { hoistImports: true },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === "x"));
-    assert.ok(imports.some((n) => n.source.value === "y"));
-    assert.ok(findCalls(code).some((c) => c.callee?.property?.name === "deepEqual"));
+    assert.ok(imports.some((n) => n.source.value === 'x'));
+    assert.ok(imports.some((n) => n.source.value === 'y'));
+    assert.ok(
+      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+    );
   });
 });
 
-describe("transform – import renaming", () => {
-  it("renames ESM import source via resolve function", () => {
-    const resolve = (s) => (s === "my-pkg" ? "/abs/path/index.js" : null);
+describe('transform – import renaming', () => {
+  it('renames ESM import source via resolve function', () => {
+    const resolve = (s) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { foo } from "my-pkg";\nfoo //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === "/abs/path/index.js"));
-    assert.ok(!imports.some((n) => n.source.value === "my-pkg"));
+    assert.ok(imports.some((n) => n.source.value === '/abs/path/index.js'));
+    assert.ok(!imports.some((n) => n.source.value === 'my-pkg'));
   });
 
-  it("renames subpath imports", () => {
-    const resolve = (s) => (s === "my-pkg/utils" ? "/abs/path/utils.js" : null);
+  it('renames subpath imports', () => {
+    const resolve = (s) => (s === 'my-pkg/utils' ? '/abs/path/utils.js' : null);
     const { code } = transform(
       assembled(3, 'import { bar } from "my-pkg/utils";\nbar //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
-    assert.ok(findImports(code).some((n) => n.source.value === "/abs/path/utils.js"));
+    assert.ok(
+      findImports(code).some((n) => n.source.value === '/abs/path/utils.js'),
+    );
   });
 
-  it("renames require() calls in body", () => {
-    const resolve = (s) => (s === "my-pkg" ? "/abs/path/index.js" : null);
+  it('renames require() calls in body', () => {
+    const resolve = (s) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
     const { code } = transform(
       assembled(3, 'const x = require("my-pkg");\nx //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const body = parse(code).body;
-    const decl = body.find((n) =>
-      n.type === "VariableDeclaration" &&
-      n.declarations[0]?.init?.callee?.name === "require" &&
-      n.declarations[0]?.init?.arguments[0]?.value !== "node:assert/strict",
+    const decl = body.find(
+      (n) =>
+        n.type === 'VariableDeclaration' &&
+        n.declarations[0]?.init?.callee?.name === 'require' &&
+        n.declarations[0]?.init?.arguments[0]?.value !== 'node:assert/strict',
     );
     assert.ok(decl);
-    assert.equal(decl.declarations[0].init.arguments[0].value, "/abs/path/index.js");
+    assert.equal(
+      decl.declarations[0].init.arguments[0].value,
+      '/abs/path/index.js',
+    );
   });
 
-  it("handles $ in resolved file paths", () => {
-    const resolve = (s) => (s === "my-pkg" ? "/path/$1/index.js" : null);
+  it('handles $ in resolved file paths', () => {
+    const resolve = (s) => (s === 'my-pkg' ? '/path/$1/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { foo } from "my-pkg";\nfoo //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
-    assert.ok(findImports(code).some((n) => n.source.value === "/path/$1/index.js"));
+    assert.ok(
+      findImports(code).some((n) => n.source.value === '/path/$1/index.js'),
+    );
   });
 });
 
-describe("transform – assertion comments", () => {
-  it("transforms //=> to assert.deepEqual", () => {
-    const { code } = transform(assembled(3, "1 + 1 //=> 2\n"), { hoistImports: true });
-    assert.ok(findCalls(code).some((c) => c.callee?.property?.name === "deepEqual"));
+describe('transform – assertion comments', () => {
+  it('transforms //=> to assert.deepEqual', () => {
+    const { code } = transform(assembled(3, '1 + 1 //=> 2\n'), {
+      hoistImports: true,
+    });
+    assert.ok(
+      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+    );
   });
 
-  it("escapes double quotes in error messages", () => {
-    const { code } = transform(assembled(3, 'fn() //=> Error: expected "foo"\n'), { hoistImports: true });
-    const throwsCall = findCalls(code).find((c) => c.callee?.property?.name === "throws");
+  it('escapes double quotes in error messages', () => {
+    const { code } = transform(
+      assembled(3, 'fn() //=> Error: expected "foo"\n'),
+      { hoistImports: true },
+    );
+    const throwsCall = findCalls(code).find(
+      (c) => c.callee?.property?.name === 'throws',
+    );
     assert.ok(throwsCall);
     const msgProp = throwsCall.arguments[1].properties.find(
-      (p) => p.key.name === "message" || p.key.value === "message",
+      (p) => p.key.name === 'message' || p.key.value === 'message',
     );
     assert.ok(msgProp.value.value.includes('"foo"'));
   });
 
-  it("escapes backslashes in error messages", () => {
-    const { code } = transform(assembled(3, "fn() //=> Error: path\\to\\file\n"), { hoistImports: true });
-    const throwsCall = findCalls(code).find((c) => c.callee?.property?.name === "throws");
-    const msgProp = throwsCall.arguments[1].properties.find(
-      (p) => p.key.name === "message" || p.key.value === "message",
+  it('escapes backslashes in error messages', () => {
+    const { code } = transform(
+      assembled(3, 'fn() //=> Error: path\\to\\file\n'),
+      { hoistImports: true },
     );
-    assert.ok(msgProp.value.value.includes("path\\to\\file"));
+    const throwsCall = findCalls(code).find(
+      (c) => c.callee?.property?.name === 'throws',
+    );
+    const msgProp = throwsCall.arguments[1].properties.find(
+      (p) => p.key.name === 'message' || p.key.value === 'message',
+    );
+    assert.ok(msgProp.value.value.includes('path\\to\\file'));
   });
 });
 
-describe("transform – sourcemaps", () => {
-  it("generates sourcemap when sourceMapSource is provided", () => {
-    const { map } = transform(assembled(3, "1 + 1 //=> 2\n"), { hoistImports: true, sourceMapSource: "readme.md" });
+describe('transform – sourcemaps', () => {
+  it('generates sourcemap when sourceMapSource is provided', () => {
+    const { map } = transform(assembled(3, '1 + 1 //=> 2\n'), {
+      hoistImports: true,
+      sourceMapSource: 'readme.md',
+    });
     assert.ok(map);
     assert.equal(map.version, 3);
-    assert.deepEqual(map.sources, ["readme.md"]);
+    assert.deepEqual(map.sources, ['readme.md']);
   });
 
-  it("produces non-trivial mappings", () => {
-    const { map } = transform(assembled(5, "x; //=> 999\n"), { hoistImports: true, sourceMapSource: "test.md" });
+  it('produces non-trivial mappings', () => {
+    const { map } = transform(assembled(5, 'x; //=> 999\n'), {
+      hoistImports: true,
+      sourceMapSource: 'test.md',
+    });
     assert.ok(map.mappings.length > 1);
   });
 });
 
-describe("transform – combined", () => {
-  it("renames, hoists, and transforms assertions in one pass", () => {
-    const resolve = (s) => (s === "my-pkg" ? "/src/index.js" : null);
+describe('transform – combined', () => {
+  it('renames, hoists, and transforms assertions in one pass', () => {
+    const resolve = (s) => (s === 'my-pkg' ? '/src/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { add } from "my-pkg";\nadd(1, 2) //=> 3\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === "node:assert/strict"));
-    assert.ok(imports.some((n) => n.source.value === "/src/index.js"));
-    assert.ok(findCalls(code).some((c) => c.callee?.property?.name === "deepEqual"));
+    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
+    assert.ok(imports.some((n) => n.source.value === '/src/index.js'));
+    assert.ok(
+      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+    );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add JSDoc type annotations to all `src/` files with `@param`, `@returns`, `@typedef`, and `@import` tags
- Add `tsconfig.json` with `checkJs`, `strict`, `noEmit` — TypeScript validates the JSDoc types without emitting anything
- Add `.prettierrc` (single quotes, trailing commas) and format the entire codebase
- Add `typecheck`, `format`, and `format:check` npm scripts
- CI now runs `format:check` and `typecheck` before tests

## Test plan

- [x] `tsc --noEmit` passes clean
- [x] `prettier --check .` passes
- [x] All 101 tests pass