### PR TITLE
Copy loc objects in stampLoc instead of sharing references

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -111,7 +111,7 @@ export function isConsoleCall(expr) {
 
 /**
  * @param {Comment[]} comments
- * @param {AstNode} node
+ * @param {AstNode & { expression: AstNode }} node
  * @param {string} code
  * @returns {Comment | null}
  */

--- a/src/ast.js
+++ b/src/ast.js
@@ -118,8 +118,9 @@ export function isConsoleCall(expr) {
 export function findTrailingComment(comments, node, code) {
   for (const c of comments) {
     if (c.type !== 'Line') continue;
-    if (c.start < node.expression.end) continue;
-    const between = code.slice(node.expression.end, c.start);
+    const exprEnd = /** @type {number} */ (node.expression.end);
+    if (c.start < exprEnd) continue;
+    const between = code.slice(exprEnd, c.start);
     if (between.includes('\n')) continue;
     return c;
   }

--- a/src/ast.js
+++ b/src/ast.js
@@ -178,6 +178,6 @@ export function addLoc(ast, source) {
  */
 export function stampLoc(node, loc) {
   walkAst(node, (n) => {
-    n.loc = loc;
+    n.loc = { start: { ...loc.start }, end: { ...loc.end } };
   });
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -189,7 +189,7 @@ function applyAssertions(ast, comments, code) {
     const node = /** @type {AstNode} */ (ast.body[i]);
     if (node.type !== 'ExpressionStatement') continue;
 
-    const comment = findTrailingComment(comments, node, code);
+    const comment = findTrailingComment(comments, /** @type {AstNode & { expression: AstNode }} */ (node), code);
     if (!comment) continue;
 
     const isAwait = node.expression.type === 'AwaitExpression';

--- a/src/transform.js
+++ b/src/transform.js
@@ -189,7 +189,11 @@ function applyAssertions(ast, comments, code) {
     const node = /** @type {AstNode} */ (ast.body[i]);
     if (node.type !== 'ExpressionStatement') continue;
 
-    const comment = findTrailingComment(comments, /** @type {AstNode & { expression: AstNode }} */ (node), code);
+    const comment = findTrailingComment(
+      comments,
+      /** @type {AstNode & { expression: AstNode }} */ (node),
+      code,
+    );
     if (!comment) continue;
 
     const isAwait = node.expression.type === 'AwaitExpression';

--- a/src/transform.js
+++ b/src/transform.js
@@ -37,6 +37,9 @@ import {
  * }} TransformOptions
  */
 
+/** @param {unknown} x @returns {AstNode} */
+const asNode = (x) => /** @type {AstNode} */ (x);
+
 /**
  * @param {string} code
  * @param {{ typescript?: boolean }} [options]
@@ -67,23 +70,14 @@ export function transform(
   const ast = result.program;
   const comments = result.comments;
 
-  addLoc(/** @type {AstNode} */ (/** @type {unknown} */ (ast)), code);
+  addLoc(asNode(ast), code);
 
   let isESM = false;
   if (hoistImports) {
-    isESM = doHoist(
-      /** @type {AstNode} */ (/** @type {unknown} */ (ast)),
-      code,
-      renameImports,
-      requireMode,
-    );
+    isESM = doHoist(asNode(ast), code, renameImports, requireMode);
   }
 
-  applyAssertions(
-    /** @type {AstNode} */ (/** @type {unknown} */ (ast)),
-    comments,
-    code,
-  );
+  applyAssertions(asNode(ast), comments, code);
 
   const printed = print(/** @type {any} */ (ast), ts(), {
     sourceMapSource: sourceMapSource || undefined,
@@ -119,9 +113,7 @@ function doHoist(ast, code, resolve, requireMode) {
   }
 
   if (resolve) {
-    for (const call of findRequireCalls(
-      /** @type {AstNode} */ (/** @type {unknown} */ ({ body })),
-    )) {
+    for (const call of findRequireCalls(asNode({ body }))) {
       renameStringLiteral(call.arguments[0], resolve);
     }
   }
@@ -154,9 +146,7 @@ function doHoist(ast, code, resolve, requireMode) {
     isESM = true;
   }
 
-  const assertNode = /** @type {AstNode} */ (
-    /** @type {unknown} */ (parseSync('t.js', assertCode).program.body[0])
-  );
+  const assertNode = asNode(parseSync('t.js', assertCode).program.body[0]);
   const firstNode = declarations[0] || body[0];
   if (firstNode)
     stampLoc(assertNode, /** @type {SourceLocation} */ (firstNode.loc));
@@ -277,7 +267,7 @@ function applyAssertions(ast, comments, code) {
 function parseExpr(text) {
   const expr = parseSync('t.js', `(${text})`, { preserveParens: false }).program
     .body[0];
-  const exprStmt = /** @type {AstNode} */ (/** @type {unknown} */ (expr));
+  const exprStmt = asNode(expr);
   return exprStmt.expression.type === 'ParenthesizedExpression'
     ? exprStmt.expression.expression
     : exprStmt.expression;


### PR DESCRIPTION
## Summary
- `stampLoc` previously assigned the same `loc` object reference to every node in the subtree
- Now each node gets a shallow copy so mutating one node's loc can't affect others

This was part of #134 but got dropped by the squash merge.

## Test plan
- [x] All 105 tests pass
- [x] All example workspace tests pass