### PR TITLE
Fix minor correctness issues in transform.js

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -173,7 +173,7 @@ function renameSpecifiers(node, resolve) {
  */
 function renameStringLiteral(literal, resolve) {
   const newPath = resolve(literal.value);
-  if (newPath) {
+  if (newPath != null) {
     literal.value = newPath;
     literal.raw = JSON.stringify(newPath);
   }
@@ -200,8 +200,12 @@ function applyAssertions(ast, comments, code) {
     const expr = node.expression;
 
     const match = comment.value.match(/^\s*(=>|→|->)\s*([\s\S]*)$/);
-    const throwsMatch = comment.value.match(/^\s*throws(?:\s+([\s\S]*))?$/);
-    const rejectsMatch = comment.value.match(/^\s*rejects(?:\s+([\s\S]*))?$/);
+    const throwsMatch =
+      !match && comment.value.match(/^\s*throws(?:\s+([\s\S]*))?$/);
+    const rejectsMatch =
+      !match &&
+      !throwsMatch &&
+      comment.value.match(/^\s*rejects(?:\s+([\s\S]*))?$/);
 
     /** @type {AstNode[] | undefined} */
     let newNodes;
@@ -217,7 +221,8 @@ function applyAssertions(ast, comments, code) {
 
       if (resolvesMatch) {
         const val = parseExpr(resolvesMatch[1].trim());
-        newNodes = [stmt(assertCall('deepEqual', [awaitNode(expr), val]))];
+        const awaited = isAwait ? expr : awaitNode(expr);
+        newNodes = [stmt(assertCall('deepEqual', [awaited, val]))];
       } else if (rejectsErrorMatch) {
         const matcher = errorMatcher(
           rejectsErrorMatch[1],
@@ -231,7 +236,7 @@ function applyAssertions(ast, comments, code) {
         newNodes = [
           throwsOrRejects(expr, matcher, { isAwait, useRejects: false }),
         ];
-      } else if (isConsoleCall(expr)) {
+      } else if (isConsoleCall(expr) && expr.arguments.length > 0) {
         const arg = expr.arguments[0];
         const val = parseExpr(rest);
         newNodes = [node, stmt(assertCall('deepEqual', [arg, val]))];
@@ -269,9 +274,10 @@ function applyAssertions(ast, comments, code) {
  * @returns {AstNode}
  */
 function parseExpr(text) {
-  const expr = parseSync('t.js', `(${text})`, { preserveParens: false }).program
-    .body[0];
-  const exprStmt = asNode(expr);
+  const result = parseSync('t.js', `(${text})`, { preserveParens: false });
+  if (result.errors.length)
+    throw new Error(`Invalid assertion expression: ${text}`);
+  const exprStmt = asNode(result.program.body[0]);
   return exprStmt.expression.type === 'ParenthesizedExpression'
     ? exprStmt.expression.expression
     : exprStmt.expression;


### PR DESCRIPTION
## Summary

- **Parse error diagnostic**: `parseExpr` now checks `oxc-parser` errors and throws a descriptive message instead of crashing opaquely on invalid assertion expressions
- **Double-await fix**: The `//=> resolves to` path no longer wraps an already-awaited expression in a redundant `await`
- **Console.log guard**: The console assertion path checks `arguments.length > 0` to avoid producing a malformed AST from `console.log()` with no arguments
- **Falsy-but-valid rename**: `renameStringLiteral` uses `!= null` instead of truthiness so an empty-string return from the resolver isn't silently ignored
- **Short-circuit regexes**: `throwsMatch` and `rejectsMatch` skip their regex when the arrow `match` already succeeded, making the mutual exclusivity explicit

## Test plan

- [x] All 113 existing tests pass
- [x] All 10 workspace example projects pass