### PR TITLE
Wrap each code fence in a node:test test() block

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -7,6 +7,7 @@
  *   code: string,
  *   name: string,
  *   hasTypescript: boolean,
+ *   blocks: Array<{ startLine: number, endLine: number }>,
  * }} Unit
  */
 
@@ -50,6 +51,10 @@ export function generate({ blocks }) {
       hasTypescript: unit.blocks.some(
         (b) => b.lang === 'typescript' || b.lang === 'ts',
       ),
+      blocks: unit.blocks.map((b) => ({
+        startLine: b.startLine,
+        endLine: b.endLine,
+      })),
     })),
   };
 }

--- a/src/run.js
+++ b/src/run.js
@@ -101,10 +101,19 @@ export async function processMarkdown(filePath, options = {}) {
     }
   }
 
+  const relPath =
+    path.relative(process.cwd(), filePath) || path.basename(filePath);
+
   /** @type {ProcessedUnit[]} */
   const results = [];
   for (const unit of units) {
     let code = unit.code;
+
+    const testBlocks = unit.blocks.map((b) => ({
+      label: `${relPath}:${b.startLine}`,
+      startLine: b.startLine,
+      endLine: b.endLine,
+    }));
 
     const transformed = transform(code, {
       typescript: unit.hasTypescript,
@@ -112,6 +121,7 @@ export async function processMarkdown(filePath, options = {}) {
       hoistImports: true,
       requireMode: (options.require?.length ?? 0) > 0,
       sourceMapSource: filePath,
+      testBlocks,
     });
     code = transformed.code;
 
@@ -222,89 +232,7 @@ function exec(cmd, args, code, cwd, mdPath, stream) {
       stderr = stderr.replaceAll('[stdin]', mdPath);
       stdout = stdout.replaceAll('[stdin]', mdPath);
 
-      if (exitCode !== 0) {
-        stderr = formatError(stderr, mdPath);
-      }
-
       resolve({ exitCode: exitCode ?? 1, stdout, stderr });
     });
   });
-}
-
-/**
- * @param {string} stderr
- * @param {string} mdPath
- * @returns {string}
- */
-function formatError(stderr, mdPath) {
-  const locMatch = stderr.match(
-    new RegExp(`${escapeRegExp(mdPath)}:(\\d+):(\\d+)`),
-  );
-  const line = locMatch ? parseInt(locMatch[1]) : null;
-  const actualMatch = stderr.match(/actual: (.+)/);
-  const expectedMatch = stderr.match(/expected: (.+)/);
-  const msgMatch = stderr.match(/AssertionError.*?:\s*(.+)/);
-  const genericMatch = !msgMatch && stderr.match(/(\w*Error.*)/);
-
-  /** @type {string[]} */
-  const parts = [];
-  const relPath = path.relative(process.cwd(), mdPath);
-  if (line) {
-    parts.push(`\n  FAIL  ${relPath}:${line}\n`);
-  } else {
-    parts.push(`\n  FAIL  ${relPath}\n`);
-  }
-
-  if (line) {
-    try {
-      const mdLines = fs.readFileSync(mdPath, 'utf-8').split('\n');
-      const start = Math.max(0, line - 3);
-      const end = Math.min(mdLines.length, line + 2);
-      for (let i = start; i < end; i++) {
-        const lineNum = String(i + 1).padStart(4);
-        const marker = i + 1 === line ? ' > ' : '   ';
-        parts.push(`${marker}${lineNum} | ${mdLines[i]}`);
-      }
-      parts.push('');
-    } catch {
-      // ignore read errors
-    }
-  }
-
-  if (actualMatch && expectedMatch) {
-    parts.push(`  expected: ${expectedMatch[1].replace(/,\s*$/, '')}`);
-    parts.push(`  received: ${actualMatch[1].replace(/,\s*$/, '')}`);
-    parts.push('');
-  } else if (msgMatch) {
-    parts.push(`  ${msgMatch[0]}`);
-    parts.push('');
-  } else if (genericMatch) {
-    parts.push(`  ${genericMatch[1]}`);
-    parts.push('');
-  } else {
-    // Fallback: strip Node internals and return cleaned stderr
-    parts.push(
-      stderr
-        .split('\n')
-        .filter(
-          (l) =>
-            !l.match(
-              /^\s*(at [a-z].*\(node:|node:internal|Node\.js v|triggerUncaught|\^$)/i,
-            ),
-        )
-        .join('\n')
-        .trim(),
-    );
-    parts.push('');
-  }
-
-  return parts.join('\n');
-}
-
-/**
- * @param {string} s
- * @returns {string}
- */
-function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -34,6 +34,7 @@ import {
  *   hoistImports?: boolean,
  *   requireMode?: boolean,
  *   sourceMapSource?: string | null,
+ *   testBlocks?: Array<{ label: string, startLine: number, endLine: number }> | null,
  * }} TransformOptions
  */
 
@@ -63,6 +64,7 @@ export function transform(
     hoistImports = false,
     requireMode = false,
     sourceMapSource = null,
+    testBlocks = null,
   } = {},
 ) {
   const ext = typescript ? 'test.ts' : 'test.js';
@@ -73,11 +75,18 @@ export function transform(
   addLoc(asNode(ast), code);
 
   let isESM = false;
+  let preambleEnd = 0;
   if (hoistImports) {
-    isESM = doHoist(asNode(ast), code, renameImports, requireMode);
+    const hoisted = doHoist(asNode(ast), code, renameImports, requireMode);
+    isESM = hoisted.isESM;
+    preambleEnd = hoisted.preambleEnd;
   }
 
   applyAssertions(asNode(ast), comments, code);
+
+  if (testBlocks?.length) {
+    wrapInTest(asNode(ast), testBlocks, preambleEnd, isESM);
+  }
 
   const printed = print(/** @type {any} */ (ast), ts(), {
     sourceMapSource: sourceMapSource || undefined,
@@ -95,7 +104,7 @@ export function transform(
  * @param {string} code
  * @param {((specifier: string) => string | null) | null} resolve
  * @param {boolean} requireMode
- * @returns {boolean}
+ * @returns {{ isESM: boolean, preambleEnd: number }}
  */
 function doHoist(ast, code, resolve, requireMode) {
   /** @type {AstNode[]} */
@@ -152,7 +161,7 @@ function doHoist(ast, code, resolve, requireMode) {
     stampLoc(assertNode, /** @type {SourceLocation} */ (firstNode.loc));
   ast.body = [assertNode, ...declarations, ...body];
 
-  return isESM;
+  return { isESM, preambleEnd: 1 + declarations.length };
 }
 
 /**
@@ -265,6 +274,57 @@ function applyAssertions(ast, comments, code) {
       i += newNodes.length - 1;
     }
   }
+}
+
+/**
+ * @param {AstNode} ast
+ * @param {Array<{ label: string, startLine: number, endLine: number }>} blocks
+ * @param {number} preambleEnd
+ * @param {boolean} isESM
+ */
+function wrapInTest(ast, blocks, preambleEnd, isESM) {
+  const preamble = ast.body.slice(0, preambleEnd);
+  const body = ast.body.slice(preambleEnd);
+
+  /** @type {Map<number, AstNode[]>} */
+  const groups = new Map();
+  for (let i = 0; i < blocks.length; i++) groups.set(i, []);
+
+  for (const node of body) {
+    const line = node.loc?.start?.line ?? 0;
+    let placed = false;
+    for (let i = 0; i < blocks.length; i++) {
+      if (line >= blocks[i].startLine && line <= blocks[i].endLine) {
+        /** @type {AstNode[]} */ (groups.get(i)).push(node);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) preamble.push(node);
+  }
+
+  const testStmts = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const stmts = /** @type {AstNode[]} */ (groups.get(i));
+    if (stmts.length === 0) continue;
+    // Build wrapper with empty body, stamp it, then insert actual body.
+    // This avoids stampLoc overwriting the inner nodes' source locations.
+    const fn = arrow([], { async: true });
+    const t = stmt(call(id('test'), [literal(blocks[i].label), fn]));
+    stampLoc(t, /** @type {SourceLocation} */ (stmts[0].loc));
+    fn.body.body = stmts;
+    testStmts.push(t);
+  }
+
+  const testCode = isESM
+    ? 'import { test } from "node:test";'
+    : 'const { test } = require("node:test");';
+  const testImport = asNode(parseSync('t.js', testCode).program.body[0]);
+  const firstNode = preamble[0] || testStmts[0];
+  if (firstNode?.loc)
+    stampLoc(testImport, /** @type {SourceLocation} */ (firstNode.loc));
+
+  ast.body = [testImport, ...preamble, ...testStmts];
 }
 
 // --- AST node builders ---

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -203,7 +203,8 @@ describe('run', () => {
     // shifted later lines, pointing the error at the closing fence.
     const result = await run(path.join(fixturesDir, 'console-shift.md'));
     assert.notEqual(result.exitCode, 0);
-    assert.match(result.stderr, /console-shift\.md:6/);
+    // node:test reports error details in stdout
+    assert.match(result.stdout, /console-shift\.md:6/);
   });
 
   it('executes a TypeScript block end-to-end', async () => {


### PR DESCRIPTION
## Summary

- Each code fence now runs inside `test("file:line", ...)` from `node:test`
- Per-block pass/fail output: `✔ README.md:5 (1.2ms)`
- Removed `formatError` — `node:test` provides structured error reporting
- Source map accuracy preserved by stamping only wrapper nodes (empty-body-then-insert pattern avoids clobbering inner `loc` properties)

## Test plan

- [x] All 113 existing tests pass
- [x] All 10 workspace example projects pass
- [x] Error line test updated to check stdout (where node:test reports)