### PR TITLE
Add node-strip-types example

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,8 +83,8 @@ override:
 readme-assert --main ./src/index.js
 ```
 
-You can also point `--main` at a `.ts` file. On Node.js 22.6+ (or 23.6+
-stable), type annotations are stripped natively:
+You can also point `--main` at a `.ts` file. On Node.js 22.6+, type
+annotations are stripped natively:
 
 ```
 readme-assert --main ./src/index.ts

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,13 @@ override:
 readme-assert --main ./src/index.js
 ```
 
+You can also point `--main` at a `.ts` file. On Node.js 22.6+ (or 23.6+
+stable), type annotations are stripped natively:
+
+```
+readme-assert --main ./src/index.ts
+```
+
 ## Module Detection
 
 readme-assert detects whether your code blocks use ESM or CJS:

--- a/docs/import-renaming.md
+++ b/docs/import-renaming.md
@@ -60,8 +60,7 @@ readme-assert --main ./src/index.js
 
 ### TypeScript source with Node.js strip types
 
-On Node.js 22.6+ (with `--experimental-strip-types`) or Node.js 23.6+
-(stable), you can point `--main` directly at a `.ts` file. Node strips
+On Node.js 22.6+, you can point `--main` directly at a `.ts` file. Node strips
 the type annotations natively — no build step or external tooling
 required:
 

--- a/docs/import-renaming.md
+++ b/docs/import-renaming.md
@@ -57,3 +57,18 @@ Use `--main` to point to a different entry point:
 ```
 readme-assert --main ./src/index.js
 ```
+
+### TypeScript source with Node.js strip types
+
+On Node.js 22.6+ (with `--experimental-strip-types`) or Node.js 23.6+
+(stable), you can point `--main` directly at a `.ts` file. Node strips
+the type annotations natively — no build step or external tooling
+required:
+
+```
+readme-assert --main ./src/index.ts
+```
+
+Your TypeScript source must use explicit `.ts` extensions in relative
+imports (e.g. `import { foo } from './foo.ts'`) since Node's type
+stripping does not perform module resolution.

--- a/examples/node-strip-types/package.json
+++ b/examples/node-strip-types/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "@laat/node-strip-types",
+  "version": "8.1.0",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "test": "readme-assert --main ./src/index.ts"
+  },
+  "devDependencies": {
+    "readme-assert": "workspace:*"
+  }
+}

--- a/examples/node-strip-types/readme.md
+++ b/examples/node-strip-types/readme.md
@@ -1,0 +1,20 @@
+# node strip types
+
+> use Node.js built-in type stripping to import TypeScript source directly
+
+No external TypeScript tooling needed — Node.js (>=22.6) strips type
+annotations natively when importing `.ts` files.
+
+### Command
+
+```
+readme-assert --main ./src/index.ts
+```
+
+```ts test
+import { pow2 } from '@laat/node-strip-types';
+const a: number = pow2(2);
+a; //=> 4
+const b: number = pow2(4);
+b; //=> 16
+```

--- a/examples/node-strip-types/src/index.ts
+++ b/examples/node-strip-types/src/index.ts
@@ -1,0 +1,1 @@
+export { pow2 } from './pow2.ts';

--- a/examples/node-strip-types/src/pow2.ts
+++ b/examples/node-strip-types/src/pow2.ts
@@ -1,0 +1,1 @@
+export const pow2 = (num: number): number => num ** 2;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  examples/node-strip-types:
+    devDependencies:
+      readme-assert:
+        specifier: workspace:*
+        version: link:../..
+
   examples/ts-node:
     devDependencies:
       readme-assert:


### PR DESCRIPTION
## Summary
- Adds a new `node-strip-types` example showing `--main` pointing to a `.ts` file
- Uses Node.js built-in type stripping (no `ts-node`, `typescript`, or other external tooling)
- ESM package with typed source in `src/index.ts` and `src/pow2.ts`

## Test plan
- [x] `pnpm test` passes in the example directory
- [ ] Verify `pnpm -r test` passes from root