### PR TITLE
Replace oxc-transform with Node.js built-in type stripping

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
   },
   "packageManager": "pnpm@10.11.0",
   "engines": {
-    "node": ">=20.19.0 || >=22.12.0"
+    "node": ">=22.6.0"
   },
   "dependencies": {
     "esrap": "^2.2.5",
-    "oxc-parser": "^0.125.0",
-    "oxc-transform": "^0.125.0"
+    "oxc-parser": "^0.125.0"
   },
   "scripts": {
     "test": "node --test test/*.test.js && node src/cli.js && pnpm -r test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       oxc-parser:
         specifier: ^0.125.0
         version: 0.125.0
-      oxc-transform:
-        specifier: ^0.125.0
-        version: 0.125.0
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -862,125 +859,6 @@ packages:
   '@oxc-project/types@0.125.0':
     resolution: {integrity: sha512-s9RKLJbRR+3kEFB3mmJVPWah3cZUAl0Jzmthx6Pb/QXnlNkRwTP75tK4uVahp/ifiiTmNYMXI1+NnGP1rNurXg==}
 
-  '@oxc-transform/binding-android-arm-eabi@0.125.0':
-    resolution: {integrity: sha512-GB65R50QSNUUguYjXZkbZweSlQD/4guNmOk0gLR3lh0+3NfB9Zc5KsDQu0usPatjiRKdGC9MoR4Vcjt/O5W4cQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-transform/binding-android-arm64@0.125.0':
-    resolution: {integrity: sha512-u0IX/H/LfFk5aG5J5JfeXlNHoZH1kni85K8u3by9WGslPkAevhlrElOH8Fiaj9oDVFpJ7XpUh09Eoibwy7AoEw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-transform/binding-darwin-arm64@0.125.0':
-    resolution: {integrity: sha512-gNZOBrXCIyoulfCiQV7g1dRqWrytXE5ReYOqEC4LgMEovzO9UJgbGFuSu3UI9jBbPGhsPNf99K87k4rrwfD0Pg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-transform/binding-darwin-x64@0.125.0':
-    resolution: {integrity: sha512-VTyRbhIMehK5TAoayd7bLxQBIJmkAjq82UvS9CXWqU5q4/QHJGXMRhpq7gJExY5fmDI0wU5wn7TOxRfI+cHVRg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-transform/binding-freebsd-x64@0.125.0':
-    resolution: {integrity: sha512-GVvvPN6qxyMwH0Ni7UrqTLAzevQWR/PqkVSwoUSjSNGZ5cogcs4w+qOzKOfz3TYXk2ZHl8awdJ5C/ZYz94qusA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.125.0':
-    resolution: {integrity: sha512-l+TZveCuDUtgUiBzFQThrh9pt3eUKVjkBqEe0cT2cMZOXojvAeBin382ewaN59oFb+C32YUXYzlo2kReXRsFBg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-arm-musleabihf@0.125.0':
-    resolution: {integrity: sha512-c86Z7IRtxHmqBORbhAi2L9S4dWH+UtrxSzLxVnYhJgPiVAjAX9INZiT950a/jlLgRfzXYvL+sRkA/od8R2W+zQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-arm64-gnu@0.125.0':
-    resolution: {integrity: sha512-2rIf4IOlp8OpKO1eQS7zuYx2tXcZD+/03wp61TFXeAtlJFtE4IVjq3oHblnZ2AjuKeJ8jGjWF18XGoc1lg7UQQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-arm64-musl@0.125.0':
-    resolution: {integrity: sha512-SuSv+0BJtIRq6hv5EE77NIiYa/sO+sS88rz4iqZQyF/+OVbU82dXx1O5HxFa4OXtUf5Ydxr27tR6cNeHNJHaGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-ppc64-gnu@0.125.0':
-    resolution: {integrity: sha512-K5Ia/wvqiO7puwtrj0J12s+PyCyfnEyVMEsUKl+7GaojfbAv1qXkzgSGQZU6xFRj+VDcRFQI6CigUFSqetP0IA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-riscv64-gnu@0.125.0':
-    resolution: {integrity: sha512-1156+HZ9h0jg+zD3ZCz3p31Rxd83JnE1fV2GULGw2nnAwVquKX87om6fdorTTKEPjcIFWRxxpHNcdekm9bpxKg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-riscv64-musl@0.125.0':
-    resolution: {integrity: sha512-d+yS/zoHgCf2fRj95/b9YP3WyQ0ckp9LH+7PhuoQJztI36LfUq1L/cBIevhAhByjaIlbJjzuEJ+YCxoIXv+mOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-s390x-gnu@0.125.0':
-    resolution: {integrity: sha512-1GyUNyVcnaMkl8xpgYzS2tOJ5VcczmK914CHIvqbnuPtwFkQZ5S1yx9J1Vim8D/guH8aCjs5v0m2jaxuh5ojLw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-x64-gnu@0.125.0':
-    resolution: {integrity: sha512-750jSInxzxVY0Q5zcZCSMuXkVmOqpvb3tx4PVO+iIJt41a8ohs8zCOQJNJUQGirJ6H3c6KNUbQrPpRJ1VRbVTg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-transform/binding-linux-x64-musl@0.125.0':
-    resolution: {integrity: sha512-YvRcIqm8aQ5ySWJwBGdJrWr6CjgzixbgICSX7Q5YFUDRwHl+T5PEBH6pe6ah0eSr9YbvngmGiTW5NeLaliBiZg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-transform/binding-openharmony-arm64@0.125.0':
-    resolution: {integrity: sha512-sy7LwhdUOTyooFL6g9A2ZOEV6qGZFdlCNh/UL+NUqYbdaogF9aNiVt6TkO9v12uqe7vqxo/sNogNir/MdLWGzQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-transform/binding-wasm32-wasi@0.125.0':
-    resolution: {integrity: sha512-4qgEvkOaBTqZyY3GSm3cj9ROPrMVtMco28KCYDnLfvlp31L4JoSQS51iL/Eq0tAOp5amqgUl+//7PuxySlQ9LQ==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@oxc-transform/binding-win32-arm64-msvc@0.125.0':
-    resolution: {integrity: sha512-dQUsxB10NAbUtVfbs7gyY4DLUq2032VG+VY1lrI+nKv+2/9UMx3Kz39AhxcYQMknen5NEr+bbL1JMVaNe+7S8g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-transform/binding-win32-ia32-msvc@0.125.0':
-    resolution: {integrity: sha512-wLnb6AAcDmP2GvnUHt+EAe+cfHvoLsbJNDGGcbJjhgdZYM00GXck3zUf5vdZgaXq2VDUFY/mMjsvqgImZ0kWtA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-transform/binding-win32-x64-msvc@0.125.0':
-    resolution: {integrity: sha512-TTp+v6v3ckRikmcVEI/fEvPc5CO6AXGnRe1P4hruGCELyHX7xohnq02ldi6L3fp8iQXRtxLzddepshQIHP3iUQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@tsconfig/node14@1.0.3':
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
 
@@ -1220,10 +1098,6 @@ packages:
 
   oxc-parser@0.125.0:
     resolution: {integrity: sha512-6M0gEDDVMGGy+Ckg/mlLh4PL87sfKRMlkQJTVTxdcEREwDa4usWjM9n4jC6Jxa5+nc3YlZTecUs4hHjoTVWKaw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-transform@0.125.0:
-    resolution: {integrity: sha512-HjUPJQ8oQ4PwWZr2kI7VX6VOqDATVynYrUTj2g6INLn5mKmpA1zD3/ll9i9bW8zPEvDMw/9poqzhBj5mFgdFYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   p-limit@2.3.0:
@@ -2289,70 +2163,6 @@ snapshots:
 
   '@oxc-project/types@0.125.0': {}
 
-  '@oxc-transform/binding-android-arm-eabi@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-android-arm64@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-darwin-arm64@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-darwin-x64@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-freebsd-x64@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-arm-gnueabihf@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-arm-musleabihf@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-arm64-gnu@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-arm64-musl@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-ppc64-gnu@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-riscv64-gnu@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-riscv64-musl@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-s390x-gnu@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-x64-gnu@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-linux-x64-musl@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-openharmony-arm64@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-wasm32-wasi@0.125.0':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    optional: true
-
-  '@oxc-transform/binding-win32-arm64-msvc@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-win32-ia32-msvc@0.125.0':
-    optional: true
-
-  '@oxc-transform/binding-win32-x64-msvc@0.125.0':
-    optional: true
-
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
@@ -2610,29 +2420,6 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.125.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.125.0
       '@oxc-parser/binding-win32-x64-msvc': 0.125.0
-
-  oxc-transform@0.125.0:
-    optionalDependencies:
-      '@oxc-transform/binding-android-arm-eabi': 0.125.0
-      '@oxc-transform/binding-android-arm64': 0.125.0
-      '@oxc-transform/binding-darwin-arm64': 0.125.0
-      '@oxc-transform/binding-darwin-x64': 0.125.0
-      '@oxc-transform/binding-freebsd-x64': 0.125.0
-      '@oxc-transform/binding-linux-arm-gnueabihf': 0.125.0
-      '@oxc-transform/binding-linux-arm-musleabihf': 0.125.0
-      '@oxc-transform/binding-linux-arm64-gnu': 0.125.0
-      '@oxc-transform/binding-linux-arm64-musl': 0.125.0
-      '@oxc-transform/binding-linux-ppc64-gnu': 0.125.0
-      '@oxc-transform/binding-linux-riscv64-gnu': 0.125.0
-      '@oxc-transform/binding-linux-riscv64-musl': 0.125.0
-      '@oxc-transform/binding-linux-s390x-gnu': 0.125.0
-      '@oxc-transform/binding-linux-x64-gnu': 0.125.0
-      '@oxc-transform/binding-linux-x64-musl': 0.125.0
-      '@oxc-transform/binding-openharmony-arm64': 0.125.0
-      '@oxc-transform/binding-wasm32-wasi': 0.125.0
-      '@oxc-transform/binding-win32-arm64-msvc': 0.125.0
-      '@oxc-transform/binding-win32-ia32-msvc': 0.125.0
-      '@oxc-transform/binding-win32-x64-msvc': 0.125.0
 
   p-limit@2.3.0:
     dependencies:

--- a/src/run.js
+++ b/src/run.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { transformSync as transformTS } from 'oxc-transform';
 import { extractBlocks } from './extract.js';
 import { generate } from './generate.js';
 import { transform } from './transform.js';
@@ -50,6 +49,7 @@ import {
  *   code: string,
  *   name: string,
  *   isESM: boolean,
+ *   hasTypescript: boolean,
  * }} ProcessedUnit
  */
 
@@ -135,10 +135,6 @@ export async function processMarkdown(filePath, options = {}) {
     });
     code = transformed.code;
 
-    if (unit.hasTypescript) {
-      code = transformTS('test.ts', code).code;
-    }
-
     if (transformed.map) {
       const mapBase64 = Buffer.from(JSON.stringify(transformed.map)).toString(
         'base64',
@@ -146,7 +142,12 @@ export async function processMarkdown(filePath, options = {}) {
       code += `\n//# sourceMappingURL=data:application/json;base64,${mapBase64}\n`;
     }
 
-    results.push({ code, name: unit.name, isESM: transformed.isESM });
+    results.push({
+      code,
+      name: unit.name,
+      isESM: transformed.isESM,
+      hasTypescript: unit.hasTypescript,
+    });
   }
 
   return { units: results, identifiers };
@@ -178,7 +179,8 @@ export async function run(filePath, options = {}) {
   const stream = options.stream ?? false;
 
   for (const unit of units) {
-    const inputType = unit.isESM ? 'module' : 'commonjs';
+    let inputType = unit.isESM ? 'module' : 'commonjs';
+    if (unit.hasTypescript) inputType += '-typescript';
     /** @type {string[]} */
     const nodeArgs = [
       '--enable-source-maps',

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -74,21 +74,13 @@ describe('processMarkdown', () => {
     );
   });
 
-  it('strips TypeScript types via esbuild for ts blocks', async () => {
+  it('preserves TypeScript types for ts blocks and marks unit', async () => {
     const { units } = await processMarkdown(
       path.join(fixturesDir, 'typescript.md'),
     );
     assert.equal(units.length, 1);
+    assert.equal(units[0].hasTypescript, true);
     const code = units[0].code;
-    // esbuild should have removed the TS type annotations
-    assert.ok(
-      !code.includes(': number'),
-      `expected no ": number" in:\n${code}`,
-    );
-    assert.ok(
-      !code.includes(': string'),
-      `expected no ": string" in:\n${code}`,
-    );
     // The assert calls should still be there
     assert.ok(code.includes('assert.deepEqual(a, 2);'));
     assert.ok(code.includes('assert.deepEqual(label, "two");'));


### PR DESCRIPTION
## Summary
- Use `--input-type=module-typescript` / `commonjs-typescript` to let Node.js strip types natively instead of doing it with `oxc-transform`
- Remove `oxc-transform` from dependencies (keeps `oxc-parser` for AST parsing)
- Bump engine requirement from `>=20.19.0 || >=22.12.0` to `>=22.6.0`

## Test plan
- [x] `node --test test/*.test.js` — 114 tests pass
- [x] `node src/cli.js` — self-test passes
- [x] `pnpm -r test` — all 12 examples pass