### PR TITLE
Use strictEqual for primitives, deepStrictEqual for objects/arrays

### DIFF
--- a/.claude/skills/readme-assertify.md
+++ b/.claude/skills/readme-assertify.md
@@ -107,4 +107,4 @@ README natural and readable.
   modify global state may need mocking or should be left unconverted.
 - **`console.log` is special.** readme-assert preserves the console.log call and
   asserts on its first argument: `console.log(x) //=> 42` becomes both the log
-  call and `assert.deepEqual(x, 42)`.
+  call and `assert.strictEqual(x, 42)`.

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -1,9 +1,10 @@
 # Assertion Syntax
 
 readme-assert transforms special comments in your code blocks into
-`assert.deepEqual()` or `assert.throws()` calls.
+assertion calls. Primitives use `assert.strictEqual()`, while objects and
+arrays use `assert.deepStrictEqual()`. Error assertions use `assert.throws()`.
 
-## Deep Equal
+## Equality
 
 Use `//=>` after an expression to assert its value:
 
@@ -88,7 +89,8 @@ The `to` is optional:
 fetch('/api'); //=> resolves { ok: true }
 ```
 
-This generates `assert.deepEqual(await expr, value)`.
+This generates `assert.strictEqual(await expr, value)` for primitives, or
+`assert.deepStrictEqual(await expr, value)` for objects and arrays.
 
 ## Rejects
 
@@ -131,5 +133,5 @@ readme-assert generates:
 
 ```javascript
 const { default: assert } = await import('node:assert/strict');
-assert.deepEqual(1 + 1, 2);
+assert.strictEqual(1 + 1, 2);
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ That's it. If any assertion fails, the process exits with a non-zero code.
 
 1. Each fenced code block is extracted from the markdown
 2. Blocks with the same `test:group` name are merged; others run independently
-3. Assertion comments (`//=> value`) are transformed into `assert.deepEqual()` calls
+3. Assertion comments (`//=> value`) are transformed into `assert.strictEqual()` or `assert.deepStrictEqual()` calls
 4. Imports of your package name are rewritten to point to your local source
 5. Each block is written to a temp file and executed with `node`
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -231,7 +231,7 @@ function applyAssertions(ast, comments, code) {
       if (resolvesMatch) {
         const val = parseExpr(resolvesMatch[1].trim());
         const awaited = isAwait ? expr : awaitNode(expr);
-        newNodes = [stmt(assertCall('deepEqual', [awaited, val]))];
+        newNodes = [stmt(assertCall(equalMethod(val), [awaited, val]))];
       } else if (rejectsErrorMatch) {
         const matcher = errorMatcher(
           rejectsErrorMatch[1],
@@ -248,10 +248,10 @@ function applyAssertions(ast, comments, code) {
       } else if (isConsoleCall(expr) && expr.arguments.length > 0) {
         const arg = expr.arguments[0];
         const val = parseExpr(rest);
-        newNodes = [node, stmt(assertCall('deepEqual', [arg, val]))];
+        newNodes = [node, stmt(assertCall(equalMethod(val), [arg, val]))];
       } else {
         const val = parseExpr(rest);
-        newNodes = [stmt(assertCall('deepEqual', [expr, val]))];
+        newNodes = [stmt(assertCall(equalMethod(val), [expr, val]))];
       }
     } else if (throwsMatch) {
       const rest = throwsMatch[1]?.trim();
@@ -325,6 +325,16 @@ function wrapInTest(ast, blocks, preambleEnd, isESM) {
     stampLoc(testImport, /** @type {SourceLocation} */ (firstNode.loc));
 
   ast.body = [testImport, ...preamble, ...testStmts];
+}
+
+/**
+ * @param {AstNode} node
+ * @returns {string}
+ */
+function equalMethod(node) {
+  return node.type === 'ObjectExpression' || node.type === 'ArrayExpression'
+    ? 'deepStrictEqual'
+    : 'strictEqual';
 }
 
 // --- AST node builders ---

--- a/src/transform.js
+++ b/src/transform.js
@@ -332,9 +332,10 @@ function wrapInTest(ast, blocks, preambleEnd, isESM) {
  * @returns {string}
  */
 function equalMethod(node) {
-  return node.type === 'ObjectExpression' || node.type === 'ArrayExpression'
-    ? 'deepStrictEqual'
-    : 'strictEqual';
+  if (node.type === 'Literal') return 'strictEqual';
+  if (node.type === 'Identifier' && node.name === 'undefined')
+    return 'strictEqual';
+  return 'deepStrictEqual';
 }
 
 // --- AST node builders ---

--- a/test/comment-to-assert.test.js
+++ b/test/comment-to-assert.test.js
@@ -94,6 +94,16 @@ describe('commentToAssert', () => {
     assert.equal(call.arguments[1].value, 'hello');
   });
 
+  it('uses deepStrictEqual for identifier expected values', () => {
+    const call = assertCall(commentToAssert('x //=> expected').code);
+    assert.equal(methodName(call), 'assert.deepStrictEqual');
+  });
+
+  it('uses strictEqual for undefined', () => {
+    const call = assertCall(commentToAssert('x //=> undefined').code);
+    assert.equal(methodName(call), 'assert.strictEqual');
+  });
+
   it('leaves non-assertion code untouched', () => {
     const input = 'const x = 1;\nconst y = 2;';
     assert.equal(commentToAssert(input).code, input);

--- a/test/comment-to-assert.test.js
+++ b/test/comment-to-assert.test.js
@@ -4,25 +4,25 @@ import { commentToAssert } from '../src/transform.js';
 import { parse, assertCall, assertAwaitedCall, methodName } from './helpers.js';
 
 describe('commentToAssert', () => {
-  it('transforms //=> to assert.deepEqual', () => {
+  it('transforms //=> to assert.strictEqual for primitives', () => {
     const call = assertCall(commentToAssert('1 + 1 //=> 2').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
     assert.equal(call.arguments.length, 2);
   });
 
   it('transforms // => with space', () => {
     const call = assertCall(commentToAssert('x // => 42').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
   });
 
   it('transforms // → with utf-8 arrow', () => {
     const call = assertCall(commentToAssert('a // → 1').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
   });
 
   it('transforms // -> with ascii arrow', () => {
     const call = assertCall(commentToAssert('a // -> 1').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
   });
 
   it('transforms // throws to assert.throws', () => {
@@ -53,7 +53,7 @@ describe('commentToAssert', () => {
       .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression);
     assert.ok(calls.some((c) => c.callee?.object?.name === 'console'));
-    assert.ok(calls.some((c) => methodName(c) === 'assert.deepEqual'));
+    assert.ok(calls.some((c) => methodName(c) === 'assert.deepStrictEqual'));
   });
 
   it('console.log with multiple statements', () => {
@@ -65,19 +65,19 @@ describe('commentToAssert', () => {
       .map((n) => n.expression)
       .filter((e) => e.type === 'CallExpression');
     const methods = calls.map(methodName);
-    assert.ok(methods.includes('assert.deepEqual'));
+    assert.ok(methods.includes('assert.strictEqual'));
     assert.ok(methods.includes('console.log'));
   });
 
   it('handles object expected values', () => {
     const call = assertCall(commentToAssert('x //=> { a: 1, b: 2 }').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.deepStrictEqual');
     assert.equal(call.arguments[1].type, 'ObjectExpression');
   });
 
   it('handles array expected values', () => {
     const call = assertCall(commentToAssert('arr //=> [1, 2, 3]').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.deepStrictEqual');
     assert.equal(call.arguments[1].type, 'ArrayExpression');
   });
 
@@ -85,7 +85,7 @@ describe('commentToAssert', () => {
     const call = assertCall(
       commentToAssert('await Promise.resolve(true) //=> true').code,
     );
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
     assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 
@@ -115,7 +115,7 @@ describe('commentToAssert', () => {
       .filter((n) => n.type === 'ExpressionStatement')
       .map((n) => n.expression);
     assert.equal(calls.length, 2);
-    assert.ok(calls.every((c) => methodName(c) === 'assert.deepEqual'));
+    assert.ok(calls.every((c) => methodName(c) === 'assert.strictEqual'));
   });
 
   it('leaves regular comments alone', () => {
@@ -133,13 +133,13 @@ describe('commentToAssert', () => {
     const call = assertCall(
       commentToAssert('Promise.resolve(true) //=> resolves to true').code,
     );
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
     assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 
   it("transforms //=> resolves value (without 'to')", () => {
     const call = assertCall(commentToAssert('fetch() //=> resolves 42').code);
-    assert.equal(methodName(call), 'assert.deepEqual');
+    assert.equal(methodName(call), 'assert.strictEqual');
     assert.equal(call.arguments[0].type, 'AwaitExpression');
   });
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -16,8 +16,8 @@ describe('processMarkdown', () => {
     );
     assert.ok(units.length >= 1);
     const allCode = units.map((u) => u.code).join('\n');
-    assert.ok(allCode.includes('assert.deepEqual(a, 1);'));
-    assert.ok(allCode.includes('assert.deepEqual(b, 2);'));
+    assert.ok(allCode.includes('assert.strictEqual(a, 1);'));
+    assert.ok(allCode.includes('assert.strictEqual(b, 2);'));
   });
 
   it('transforms throws.md', async () => {
@@ -82,8 +82,8 @@ describe('processMarkdown', () => {
     assert.equal(units[0].hasTypescript, true);
     const code = units[0].code;
     // The assert calls should still be there
-    assert.ok(code.includes('assert.deepEqual(a, 2);'));
-    assert.ok(code.includes('assert.deepEqual(label, "two");'));
+    assert.ok(code.includes('assert.strictEqual(a, 2);'));
+    assert.ok(code.includes('assert.strictEqual(label, "two");'));
   });
 });
 

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -65,7 +65,7 @@ describe('transform – import hoisting', () => {
     assert.ok(imports.some((n) => n.source.value === 'x'));
     assert.ok(imports.some((n) => n.source.value === 'y'));
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
     );
   });
 });
@@ -79,7 +79,9 @@ describe('transform – typescript mode', () => {
       { hoistImports: true, ...ts },
     );
     assert.ok(
-      findCalls(code, ts).some((c) => c.callee?.property?.name === 'deepEqual'),
+      findCalls(code, ts).some(
+        (c) => c.callee?.property?.name === 'strictEqual',
+      ),
     );
   });
 
@@ -230,12 +232,12 @@ describe('transform – import renaming', () => {
 });
 
 describe('transform – assertion comments', () => {
-  it('transforms //=> to assert.deepEqual', () => {
+  it('transforms //=> to assert.strictEqual for primitives', () => {
     const { code } = transform(assembled(3, '1 + 1 //=> 2\n'), {
       hoistImports: true,
     });
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
     );
   });
 
@@ -300,7 +302,7 @@ describe('transform – combined', () => {
     assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
     assert.ok(imports.some((n) => n.source.value === '/src/index.js'));
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'deepEqual'),
+      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Assertion comments now generate type-aware assert calls instead of always using `deepEqual`
- Primitives (numbers, strings, booleans, null, undefined) use `assert.strictEqual()`
- Objects, arrays, and other complex expressions use `assert.deepStrictEqual()`

## Test plan

- [x] All 116 unit tests pass
- [x] All 4 README assertion blocks pass
- [x] All 12 example projects pass