### PR TITLE
Convert source and tests to TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,6 @@ jobs:
       - run: pnpm run format:check
       - run: pnpm run typecheck
       - run: pnpm run build
+      - run: pnpm install
       - run: pnpm test
       - run: node dist/cli.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,4 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run build
       - run: pnpm test
+      - run: node dist/cli.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - run: pnpm install
       - run: pnpm run format:check
       - run: pnpm run typecheck
-      - run: pnpm run build
-      - run: pnpm install
       - run: pnpm test
+      - run: pnpm run build
       - run: node dist/cli.js
+      - run: pnpm install
+      - run: pnpm run test:examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
       - run: pnpm install
       - run: pnpm run format:check
       - run: pnpm run typecheck
+      - run: pnpm run build
       - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+dist
 .venv
 site

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "typescript"
   ],
   "type": "module",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "readme-assert": "./dist/cli.js"
   },
@@ -41,6 +46,8 @@
     "oxc-parser": "^0.125.0"
   },
   "scripts": {
+    "clean": "rm -rf dist",
+    "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "test": "node --test test/*.test.ts && node src/cli.ts && pnpm -r test",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "typescript"
   ],
   "type": "module",
-  "exports": "./src/index.js",
+  "exports": "./dist/index.js",
   "bin": {
-    "readme-assert": "./src/cli.js"
+    "readme-assert": "./dist/cli.js"
   },
   "files": [
-    "src"
+    "dist"
   ],
   "license": "MIT",
   "author": {
@@ -41,7 +41,9 @@
     "oxc-parser": "^0.125.0"
   },
   "scripts": {
-    "test": "node --test test/*.test.js && node src/cli.js && pnpm -r test",
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run build",
+    "test": "node --test test/*.test.ts && node src/cli.ts && pnpm -r test",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build",
-    "test": "node --test test/*.test.ts && node src/cli.ts && pnpm -r test",
+    "test": "node --test test/*.test.ts && node src/cli.ts",
+    "test:examples": "pnpm -r test",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,23 +1,19 @@
 import { visitorKeys, parseSync } from 'oxc-parser';
 
-/**
- * @import { Comment, Program } from "oxc-parser"
- * @import { Node, Statement, Expression, StringLiteral, ExpressionStatement } from "@oxc-project/types"
- */
+import type { Comment } from 'oxc-parser';
 
-/**
- * @typedef {{ line: number, column: number }} Position
- * @typedef {{ start: Position, end: Position }} SourceLocation
- * @typedef {Record<string, any> & { type: string, start?: number, end?: number, loc?: SourceLocation }} AstNode
- */
+export type Position = { line: number; column: number };
+export type SourceLocation = { start: Position; end: Position };
+export type AstNode = Record<string, any> & {
+  type: string;
+  start?: number;
+  end?: number;
+  loc?: SourceLocation;
+};
 
 export const assertCommentRe = /\/\/\s*(=>|→|->|throws|rejects)/;
 
-/**
- * @param {AstNode} node
- * @param {(node: AstNode) => void} visitor
- */
-export function walkAst(node, visitor) {
+export function walkAst(node: AstNode, visitor: (node: AstNode) => void): void {
   if (!node || typeof node !== 'object') return;
   if (node.type) {
     visitor(node);
@@ -43,11 +39,7 @@ export function walkAst(node, visitor) {
   }
 }
 
-/**
- * @param {AstNode} node
- * @returns {boolean}
- */
-export function isDeclaration(node) {
+export function isDeclaration(node: AstNode): boolean {
   return (
     node.type === 'ImportDeclaration' ||
     node.type === 'ExportNamedDeclaration' ||
@@ -56,22 +48,14 @@ export function isDeclaration(node) {
   );
 }
 
-/**
- * @param {AstNode} node
- * @returns {AstNode | null}
- */
-export function getSourceNode(node) {
+export function getSourceNode(node: AstNode): AstNode | null {
   if (node.type === 'ImportDeclaration') return node.source;
   if (node.type === 'ExportNamedDeclaration' && node.source) return node.source;
   if (node.type === 'ExportAllDeclaration') return node.source;
   return null;
 }
 
-/**
- * @param {AstNode} node
- * @returns {boolean}
- */
-export function isRequireCall(node) {
+export function isRequireCall(node: AstNode): boolean {
   return (
     node.type === 'CallExpression' &&
     node.callee?.type === 'Identifier' &&
@@ -83,24 +67,15 @@ export function isRequireCall(node) {
   );
 }
 
-/**
- * @param {AstNode} node
- * @returns {AstNode[]}
- */
-export function findRequireCalls(node) {
-  /** @type {AstNode[]} */
-  const results = [];
+export function findRequireCalls(node: AstNode): AstNode[] {
+  const results: AstNode[] = [];
   walkAst(node, (n) => {
     if (isRequireCall(n)) results.push(n);
   });
   return results;
 }
 
-/**
- * @param {AstNode} expr
- * @returns {boolean}
- */
-export function isConsoleCall(expr) {
+export function isConsoleCall(expr: AstNode): boolean {
   return (
     expr.type === 'CallExpression' &&
     expr.callee?.type === 'MemberExpression' &&
@@ -109,16 +84,14 @@ export function isConsoleCall(expr) {
   );
 }
 
-/**
- * @param {Comment[]} comments
- * @param {AstNode & { expression: AstNode }} node
- * @param {string} code
- * @returns {Comment | null}
- */
-export function findTrailingComment(comments, node, code) {
+export function findTrailingComment(
+  comments: Comment[],
+  node: AstNode & { expression: AstNode },
+  code: string,
+): Comment | null {
   for (const c of comments) {
     if (c.type !== 'Line') continue;
-    const exprEnd = /** @type {number} */ (node.expression.end);
+    const exprEnd = node.expression.end as number;
     if (c.start < exprEnd) continue;
     const between = code.slice(exprEnd, c.start);
     if (between.includes('\n')) continue;
@@ -129,11 +102,7 @@ export function findTrailingComment(comments, node, code) {
 
 // --- Location utilities ---
 
-/**
- * @param {string} source
- * @returns {number[]}
- */
-export function buildLineIndex(source) {
+export function buildLineIndex(source: string): number[] {
   const starts = [0];
   for (let i = 0; i < source.length; i++) {
     if (source[i] === '\n') starts.push(i + 1);
@@ -141,12 +110,7 @@ export function buildLineIndex(source) {
   return starts;
 }
 
-/**
- * @param {number[]} lineStarts
- * @param {number} offset
- * @returns {Position}
- */
-export function offsetToLoc(lineStarts, offset) {
+export function offsetToLoc(lineStarts: number[], offset: number): Position {
   let lo = 0,
     hi = lineStarts.length - 1;
   while (lo < hi) {
@@ -157,27 +121,19 @@ export function offsetToLoc(lineStarts, offset) {
   return { line: lo + 1, column: offset - lineStarts[lo] };
 }
 
-/**
- * @param {AstNode} ast
- * @param {string} source
- */
-export function addLoc(ast, source) {
+export function addLoc(ast: AstNode, source: string): void {
   const lineStarts = buildLineIndex(source);
   walkAst(ast, (node) => {
     if ('start' in node && 'end' in node) {
       node.loc = {
-        start: offsetToLoc(lineStarts, /** @type {number} */ (node.start)),
-        end: offsetToLoc(lineStarts, /** @type {number} */ (node.end)),
+        start: offsetToLoc(lineStarts, node.start as number),
+        end: offsetToLoc(lineStarts, node.end as number),
       };
     }
   });
 }
 
-/**
- * @param {AstNode} node
- * @param {SourceLocation} loc
- */
-export function stampLoc(node, loc) {
+export function stampLoc(node: AstNode, loc: SourceLocation): void {
   walkAst(node, (n) => {
     n.loc = { start: { ...loc.start }, end: { ...loc.end } };
   });
@@ -186,13 +142,9 @@ export function stampLoc(node, loc) {
 /**
  * Parse a code snippet and return all top-level identifiers it defines
  * (imports, variables, functions, classes).
- *
- * @param {string} code
- * @returns {string[]}
  */
-export function collectDefinedIdentifiers(code) {
-  /** @type {string[]} */
-  const ids = [];
+export function collectDefinedIdentifiers(code: string): string[] {
+  const ids: string[] = [];
   let ast;
   try {
     ast = parseSync('test.js', code).program;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,26 +3,30 @@ import { parseArgs } from 'node:util';
 import path from 'node:path';
 import fs from 'node:fs';
 
-let args: any;
+const cliOptions = {
+  file: { type: 'string', short: 'f' },
+  main: { type: 'string', short: 'm' },
+  auto: { type: 'boolean', short: 'a', default: false },
+  all: { type: 'boolean', short: 'l', default: false },
+  require: { type: 'string', short: 'r', multiple: true },
+  import: { type: 'string', short: 'i', multiple: true },
+  'print-code': { type: 'boolean', short: 'p', default: false },
+  help: { type: 'boolean', short: 'h', default: false },
+  version: { type: 'boolean', short: 'v', default: false },
+} as const;
+
+let args: ReturnType<
+  typeof parseArgs<{ options: typeof cliOptions }>
+>['values'];
 let positionals: string[];
 try {
   ({ values: args, positionals } = parseArgs({
-    options: {
-      file: { type: 'string', short: 'f' },
-      main: { type: 'string', short: 'm' },
-      auto: { type: 'boolean', short: 'a', default: false },
-      all: { type: 'boolean', short: 'l', default: false },
-      require: { type: 'string', short: 'r', multiple: true },
-      import: { type: 'string', short: 'i', multiple: true },
-      'print-code': { type: 'boolean', short: 'p', default: false },
-      help: { type: 'boolean', short: 'h', default: false },
-      version: { type: 'boolean', short: 'v', default: false },
-    },
+    options: cliOptions,
     strict: true,
     allowPositionals: true,
   }));
-} catch (err: any) {
-  console.error(err.message);
+} catch (err: unknown) {
+  console.error(err instanceof Error ? err.message : err);
   console.error('Run with --help to see supported options.');
   process.exit(1);
 }
@@ -108,8 +112,11 @@ try {
     }
     process.exitCode = exitCode;
   }
-} catch (err: any) {
-  if (err?.code === 'NO_TEST_BLOCKS') {
+} catch (err: unknown) {
+  if (
+    err instanceof Error &&
+    (err as NodeJS.ErrnoException).code === 'NO_TEST_BLOCKS'
+  ) {
     const relPath = path.relative(process.cwd(), filePath);
     console.error(`No test code blocks found in ${relPath}`);
     process.exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@ import { parseArgs } from 'node:util';
 import path from 'node:path';
 import fs from 'node:fs';
 
-let args;
-let positionals;
+let args: any;
+let positionals: string[];
 try {
   ({ values: args, positionals } = parseArgs({
     options: {
@@ -21,7 +21,7 @@ try {
     strict: true,
     allowPositionals: true,
   }));
-} catch (/** @type {any} */ err) {
+} catch (err: any) {
   console.error(err.message);
   console.error('Run with --help to see supported options.');
   process.exit(1);
@@ -54,7 +54,7 @@ if (args.version) {
   process.exit(0);
 }
 
-function findReadme() {
+function findReadme(): string | null {
   for (const name of ['README.md', 'readme.md']) {
     const p = path.resolve(name);
     if (fs.existsSync(p)) return p;
@@ -80,14 +80,14 @@ const opts = {
 
 try {
   if (args['print-code']) {
-    const { processMarkdown } = await import('./run.js');
+    const { processMarkdown } = await import('./run.ts');
     const { units } = await processMarkdown(filePath, opts);
     for (const unit of units) {
       console.log(`# --- ${unit.name} ---`);
       console.log(unit.code);
     }
   } else {
-    const { run } = await import('./run.js');
+    const { run } = await import('./run.ts');
     // stream: true pipes each child's stdout to process.stdout live so
     // long-running blocks don't look stalled.
     const { exitCode, stderr, results } = await run(filePath, {
@@ -108,7 +108,7 @@ try {
     }
     process.exitCode = exitCode;
   }
-} catch (/** @type {any} */ err) {
+} catch (err: any) {
   if (err?.code === 'NO_TEST_BLOCKS') {
     const relPath = path.relative(process.cwd(), filePath);
     console.error(`No test code blocks found in ${relPath}`);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,16 +1,14 @@
-import { assertCommentRe } from './ast.js';
+import { assertCommentRe } from './ast.ts';
 
-/**
- * @typedef {{
- *   code: string,
- *   lang: string,
- *   tag: string,
- *   group: string | null,
- *   description: string | null,
- *   startLine: number,
- *   endLine: number,
- * }} Block
- */
+export type Block = {
+  code: string;
+  lang: string;
+  tag: string;
+  group: string | null;
+  description: string | null;
+  startLine: number;
+  endLine: number;
+};
 
 /**
  * Extract tagged code blocks from a markdown string.
@@ -18,20 +16,18 @@ import { assertCommentRe } from './ast.js';
  * Tags: "test", "test:groupname", "should description", "should:groupname description"
  * Blocks with the same group name are merged into a single execution unit.
  * Blocks without a group name each run independently.
- *
- * @param {string} markdown
- * @param {{ auto?: boolean, all?: boolean }} [options]
- * @returns {{ blocks: Block[], hasTypescript: boolean }}
  */
-export function extractBlocks(markdown, { auto = false, all = false } = {}) {
+export function extractBlocks(
+  markdown: string,
+  { auto = false, all = false } = {},
+): { blocks: Block[]; hasTypescript: boolean } {
   // Based on gfm-code-block-regex — the backreference \2 ensures a 4-backtick
   // fence only closes with 4 backticks, so nested display fences are skipped.
   const fenceRe = /^(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))/gm;
   const supportedLangs = new Set(['javascript', 'js', 'typescript', 'ts']);
   const tsLangs = new Set(['typescript', 'ts']);
   let hasTypescript = false;
-  /** @type {Block[]} */
-  const blocks = [];
+  const blocks: Block[] = [];
   let match;
   let prevEnd = 0;
   let lineAt = 1;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,41 +1,35 @@
-/**
- * @import { Block } from "./extract.js"
- */
+import type { Block } from './extract.ts';
 
-/**
- * @typedef {{
- *   code: string,
- *   name: string,
- *   hasTypescript: boolean,
- *   blocks: Array<{ startLine: number, endLine: number, description: string | null }>,
- * }} Unit
- */
+export type Unit = {
+  code: string;
+  name: string;
+  hasTypescript: boolean;
+  blocks: Array<{
+    startLine: number;
+    endLine: number;
+    description: string | null;
+  }>;
+};
 
-/**
- * @param {{ blocks: Block[] }} extracted
- * @returns {{ units: Unit[] }}
- */
-export function generate({ blocks }) {
+export function generate({ blocks }: { blocks: Block[] }): {
+  units: Unit[];
+} {
   if (blocks.length === 0) return { units: [] };
 
-  /** @type {Map<string, { blocks: Block[], name: string }>} */
-  const groups = new Map();
-  /** @type {{ blocks: Block[], name: string }[]} */
-  const units = [];
+  const groups = new Map<string, { blocks: Block[]; name: string }>();
+  const units: { blocks: Block[]; name: string }[] = [];
 
   for (const block of blocks) {
     if (block.group) {
       if (!groups.has(block.group)) {
         const entry = {
-          blocks: /** @type {Block[]} */ ([]),
+          blocks: [] as Block[],
           name: block.group,
         };
         groups.set(block.group, entry);
         units.push(entry);
       }
-      /** @type {{ blocks: Block[], name: string }} */ (
-        groups.get(block.group)
-      ).blocks.push(block);
+      groups.get(block.group)!.blocks.push(block);
     } else {
       units.push({
         blocks: [block],
@@ -60,11 +54,7 @@ export function generate({ blocks }) {
   };
 }
 
-/**
- * @param {Block[]} blocks
- * @returns {string}
- */
-function assembleUnit(blocks) {
+function assembleUnit(blocks: Block[]): string {
   const maxLine = Math.max(...blocks.map((b) => b.endLine));
 
   const lines = new Array(maxLine).fill('');

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,0 @@
-export { extractBlocks } from './extract.js';
-export { commentToAssert, transform } from './transform.js';
-export { generate } from './generate.js';
-export { resolveMainEntry, resolveSubpathExport } from './resolve.js';
-export { processMarkdown, run } from './run.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+export { extractBlocks } from './extract.ts';
+export { commentToAssert, transform } from './transform.ts';
+export { generate } from './generate.ts';
+export { resolveMainEntry, resolveSubpathExport } from './resolve.ts';
+export { processMarkdown, run } from './run.ts';

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -2,11 +2,11 @@
  * Custom test reporter that outputs pass/fail lines without per-process
  * summaries.  Used by the CLI so that multiple child processes don't each
  * print their own "ℹ tests 1 / ℹ pass 1 / …" block.
- *
- * @param {AsyncIterable<{ type: string, data: any }>} source
  */
-export default async function* reporter(source) {
-  const failures = [];
+export default async function* reporter(
+  source: AsyncIterable<{ type: string; data: any }>,
+) {
+  const failures: any[] = [];
   for await (const event of source) {
     if (event.type === 'test:pass') {
       const d = event.data;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,12 +1,14 @@
+import type { TestEvent } from 'node:test/reporters';
+
+type TestFail = Extract<TestEvent, { type: 'test:fail' }>['data'];
+
 /**
  * Custom test reporter that outputs pass/fail lines without per-process
  * summaries.  Used by the CLI so that multiple child processes don't each
  * print their own "ℹ tests 1 / ℹ pass 1 / …" block.
  */
-export default async function* reporter(
-  source: AsyncIterable<{ type: string; data: any }>,
-) {
-  const failures: any[] = [];
+export default async function* reporter(source: AsyncIterable<TestEvent>) {
+  const failures: TestFail[] = [];
   for await (const event of source) {
     if (event.type === 'test:pass') {
       const d = event.data;
@@ -23,8 +25,9 @@ export default async function* reporter(
       if (d.file) yield `test at ${d.file}:${d.line}:${d.column}\n`;
       yield `\u2716 ${d.name} (${d.details.duration_ms}ms)\n`;
       const cause = d.details?.error?.cause;
-      if (cause) {
-        const text = cause.stack || cause.message || String(cause);
+      if (cause && typeof cause === 'object') {
+        const err = cause as { stack?: string; message?: string };
+        const text = err.stack || err.message || String(cause);
         for (const line of text.split('\n')) {
           yield `  ${line}\n`;
         }

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -3,17 +3,11 @@ import path from 'node:path';
 
 /**
  * Package.json `exports` is a recursive structure (strings or nested
- * condition objects). JSDoc can't express recursive types, so we use
- * a pragmatic two-level approximation.
- *
- * @typedef {string | Record<string, any>} ExportsEntry
+ * condition objects).
  */
+type ExportsEntry = string | Record<string, any>;
 
-/**
- * @param {string} dir
- * @returns {string | null}
- */
-export function findPackageJson(dir) {
+export function findPackageJson(dir: string): string | null {
   let current = path.resolve(dir);
   while (true) {
     const candidate = path.join(current, 'package.json');
@@ -34,11 +28,11 @@ export function findPackageJson(dir) {
  *   - nested:          "exports": { ".": { "import": "./esm.js" } }
  *
  * Returns null if no entry can be determined.
- *
- * @param {{ main?: string, exports?: ExportsEntry }} pkg
- * @returns {string | null}
  */
-export function resolveMainEntry(pkg) {
+export function resolveMainEntry(pkg: {
+  main?: string;
+  exports?: ExportsEntry;
+}): string | null {
   if (pkg.main) return pkg.main;
 
   const exp = pkg.exports;
@@ -58,12 +52,11 @@ export function resolveMainEntry(pkg) {
  *   // => "./src/utils.js"
  *
  * Returns null when the exports map doesn't contain the subpath.
- *
- * @param {ExportsEntry} exportsMap
- * @param {string} subpath
- * @returns {string | null}
  */
-export function resolveSubpathExport(exportsMap, subpath) {
+export function resolveSubpathExport(
+  exportsMap: ExportsEntry,
+  subpath: string,
+): string | null {
   if (!exportsMap || typeof exportsMap !== 'object') return null;
   if (!isSubpathExportsMap(exportsMap)) return null;
   if (subpath in exportsMap) {
@@ -72,11 +65,7 @@ export function resolveSubpathExport(exportsMap, subpath) {
   return null;
 }
 
-/**
- * @param {ExportsEntry | undefined} node
- * @returns {string | null}
- */
-function resolveExportCondition(node) {
+function resolveExportCondition(node: ExportsEntry | undefined): string | null {
   if (node == null) return null;
   if (typeof node === 'string') return node;
   if (typeof node !== 'object') return null;
@@ -91,10 +80,6 @@ function resolveExportCondition(node) {
   return null;
 }
 
-/**
- * @param {Record<string, ExportsEntry>} exp
- * @returns {boolean}
- */
-function isSubpathExportsMap(exp) {
+function isSubpathExportsMap(exp: Record<string, ExportsEntry>): boolean {
   return Object.keys(exp).some((k) => k.startsWith('.'));
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,66 +1,52 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { extractBlocks } from './extract.js';
-import { generate } from './generate.js';
-import { transform } from './transform.js';
-import { collectDefinedIdentifiers } from './ast.js';
+import { extractBlocks } from './extract.ts';
+import { generate } from './generate.ts';
+import { transform } from './transform.ts';
+import { collectDefinedIdentifiers } from './ast.ts';
 import {
   findPackageJson,
   resolveMainEntry,
   resolveSubpathExport,
-} from './resolve.js';
+} from './resolve.ts';
 
-/**
- * @import { TransformResult } from "./transform.js"
- * @import { Unit } from "./generate.js"
- */
+type RunOptions = {
+  auto?: boolean;
+  all?: boolean;
+  main?: string;
+  stream?: boolean;
+  require?: string[];
+  import?: string[];
+};
 
-/**
- * @typedef {{
- *   auto?: boolean,
- *   all?: boolean,
- *   main?: string,
- *   stream?: boolean,
- *   require?: string[],
- *   import?: string[],
- * }} RunOptions
- */
+type ExecResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
 
-/**
- * @typedef {{
- *   exitCode: number,
- *   stdout: string,
- *   stderr: string,
- * }} ExecResult
- */
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  results: (ExecResult & { name: string })[];
+};
 
-/**
- * @typedef {{
- *   exitCode: number,
- *   stdout: string,
- *   stderr: string,
- *   results: (ExecResult & { name: string })[],
- * }} RunResult
- */
-
-/**
- * @typedef {{
- *   code: string,
- *   name: string,
- *   isESM: boolean,
- *   hasTypescript: boolean,
- * }} ProcessedUnit
- */
+type ProcessedUnit = {
+  code: string;
+  name: string;
+  isESM: boolean;
+  hasTypescript: boolean;
+};
 
 /**
  * Process a markdown file into executable code units.
- *
- * @param {string} filePath
- * @param {RunOptions} [options]
- * @returns {Promise<{ units: ProcessedUnit[], identifiers: Map<string, number> }>}
  */
-export async function processMarkdown(filePath, options = {}) {
+export async function processMarkdown(
+  filePath: string,
+  options: RunOptions = {},
+): Promise<{ units: ProcessedUnit[]; identifiers: Map<string, number> }> {
   const markdown = await fs.readFile(filePath, 'utf-8');
   const extracted = extractBlocks(markdown, {
     auto: options.auto,
@@ -68,15 +54,14 @@ export async function processMarkdown(filePath, options = {}) {
   });
 
   if (extracted.blocks.length === 0) {
-    const err = /** @type {Error & { code?: string }} */ (
-      new Error(`No test code blocks found in ${filePath}`)
-    );
+    const err = new Error(
+      `No test code blocks found in ${filePath}`,
+    ) as Error & { code?: string };
     err.code = 'NO_TEST_BLOCKS';
     throw err;
   }
 
-  /** @type {Map<string, number>} */
-  const identifiers = new Map();
+  const identifiers: Map<string, number> = new Map();
   for (const block of extracted.blocks) {
     for (const id of collectDefinedIdentifiers(block.code)) {
       identifiers.set(id, block.startLine);
@@ -85,14 +70,13 @@ export async function processMarkdown(filePath, options = {}) {
 
   const { units } = generate(extracted);
 
-  /** @type {((specifier: string) => string | null) | null} */
-  let resolve = null;
+  let resolve: ((specifier: string) => string | null) | null = null;
   const pkgPath = findPackageJson(path.dirname(filePath));
   if (pkgPath) {
     const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8'));
     if (pkg.name) {
       const mainEntry = options.main || resolveMainEntry(pkg) || './index.js';
-      const packageName = /** @type {string} */ (pkg.name);
+      const packageName = pkg.name as string;
       const packageDir = path.dirname(pkgPath);
       const localPath = path.resolve(packageDir, mainEntry);
       const exportsMap = pkg.exports;
@@ -114,8 +98,7 @@ export async function processMarkdown(filePath, options = {}) {
   const relPath =
     path.relative(process.cwd(), filePath) || path.basename(filePath);
 
-  /** @type {ProcessedUnit[]} */
-  const results = [];
+  const results: ProcessedUnit[] = [];
   for (const unit of units) {
     let code = unit.code;
 
@@ -165,26 +148,23 @@ export async function processMarkdown(filePath, options = {}) {
  * to `process.stdout` as it arrives so long-running blocks don't look
  * stalled. Captured stdout is still returned in the result for
  * programmatic callers.
- *
- * @param {string} filePath
- * @param {RunOptions} [options]
- * @returns {Promise<RunResult>}
  */
-export async function run(filePath, options = {}) {
+export async function run(
+  filePath: string,
+  options: RunOptions = {},
+): Promise<RunResult> {
   const { units, identifiers } = await processMarkdown(filePath, options);
   const dir = path.dirname(filePath);
   let allStdout = '';
   let allStderr = '';
-  /** @type {(ExecResult & { name: string })[]} */
-  const results = [];
+  const results: (ExecResult & { name: string })[] = [];
 
   const stream = options.stream ?? false;
 
   for (const unit of units) {
     let inputType = unit.isESM ? 'module' : 'commonjs';
     if (unit.hasTypescript) inputType += '-typescript';
-    /** @type {string[]} */
-    const nodeArgs = [
+    const nodeArgs: string[] = [
       '--enable-source-maps',
       `--input-type=${inputType}`,
       `--test-reporter=${reporterPath}`,
@@ -219,18 +199,19 @@ export async function run(filePath, options = {}) {
   return { exitCode, stdout: allStdout, stderr: allStderr, results };
 }
 
-const reporterPath = new URL('./reporter.js', import.meta.url).pathname;
+const reporterPath = new URL(
+  import.meta.url.endsWith('.ts') ? './reporter.ts' : './reporter.js',
+  import.meta.url,
+).pathname;
 
-/**
- * @param {string} cmd
- * @param {string[]} args
- * @param {string} code
- * @param {string} cwd
- * @param {string} mdPath
- * @param {boolean} stream
- * @returns {Promise<ExecResult>}
- */
-function exec(cmd, args, code, cwd, mdPath, stream) {
+function exec(
+  cmd: string,
+  args: string[],
+  code: string,
+  cwd: string,
+  mdPath: string,
+  stream: boolean,
+): Promise<ExecResult> {
   return new Promise((resolve) => {
     const child = spawn(cmd, args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
     child.stdin.on('error', () => {});
@@ -243,13 +224,13 @@ function exec(cmd, args, code, cwd, mdPath, stream) {
     let stdout = '';
     let stderr = '';
 
-    child.stdout.on('data', (/** @type {string} */ chunk) => {
+    child.stdout.on('data', (chunk: string) => {
       if (stream) process.stdout.write(chunk);
       stdout += chunk;
     });
-    child.stderr.on('data', (/** @type {string} */ d) => (stderr += d));
+    child.stderr.on('data', (d: string) => (stderr += d));
 
-    child.on('close', (/** @type {number | null} */ exitCode) => {
+    child.on('close', (exitCode: number | null) => {
       stderr = stderr.replaceAll('[stdin]', mdPath);
       stdout = stdout.replaceAll('[stdin]', mdPath);
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -78,7 +78,7 @@ export function transform(
     wrapInTest(asNode(ast), testBlocks, preambleEnd, isESM);
   }
 
-  const printed = print(ast as any, ts(), {
+  const printed = print(ast, ts(), {
     sourceMapSource: sourceMapSource || undefined,
     sourceMapContent: sourceMapSource ? code : undefined,
   });

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,52 +12,42 @@ import {
   findTrailingComment,
   addLoc,
   stampLoc,
-} from './ast.js';
+} from './ast.ts';
 
-/**
- * @import { Comment } from "oxc-parser"
- * @import { AstNode, SourceLocation } from "./ast.js"
- */
+import type { Comment } from 'oxc-parser';
+import type { AstNode, SourceLocation } from './ast.ts';
 
-/**
- * @typedef {{
- *   code: string,
- *   map: any,
- *   isESM: boolean,
- * }} TransformResult
- */
+type TransformResult = {
+  code: string;
+  map: any;
+  isESM: boolean;
+};
 
-/**
- * @typedef {{
- *   typescript?: boolean,
- *   renameImports?: ((specifier: string) => string | null) | null,
- *   hoistImports?: boolean,
- *   requireMode?: boolean,
- *   sourceMapSource?: string | null,
- *   testBlocks?: Array<{ label: string, startLine: number, endLine: number }> | null,
- * }} TransformOptions
- */
+type TransformOptions = {
+  typescript?: boolean;
+  renameImports?: ((specifier: string) => string | null) | null;
+  hoistImports?: boolean;
+  requireMode?: boolean;
+  sourceMapSource?: string | null;
+  testBlocks?: Array<{
+    label: string;
+    startLine: number;
+    endLine: number;
+  }> | null;
+};
 
-/** @param {unknown} x @returns {AstNode} */
-const asNode = (x) => /** @type {AstNode} */ (x);
+const asNode = (x: unknown): AstNode => x as AstNode;
 
-/**
- * @param {string} code
- * @param {{ typescript?: boolean }} [options]
- * @returns {TransformResult}
- */
-export function commentToAssert(code, { typescript = false } = {}) {
+export function commentToAssert(
+  code: string,
+  { typescript = false }: { typescript?: boolean } = {},
+): TransformResult {
   if (!assertCommentRe.test(code)) return { code, map: null, isESM: false };
   return transform(code, { typescript });
 }
 
-/**
- * @param {string} code
- * @param {TransformOptions} [options]
- * @returns {TransformResult}
- */
 export function transform(
-  code,
+  code: string,
   {
     typescript = false,
     renameImports = null,
@@ -65,8 +55,8 @@ export function transform(
     requireMode = false,
     sourceMapSource = null,
     testBlocks = null,
-  } = {},
-) {
+  }: TransformOptions = {},
+): TransformResult {
   const ext = typescript ? 'test.ts' : 'test.js';
   const result = parseSync(ext, code);
   const ast = result.program;
@@ -88,7 +78,7 @@ export function transform(
     wrapInTest(asNode(ast), testBlocks, preambleEnd, isESM);
   }
 
-  const printed = print(/** @type {any} */ (ast), ts(), {
+  const printed = print(ast as any, ts(), {
     sourceMapSource: sourceMapSource || undefined,
     sourceMapContent: sourceMapSource ? code : undefined,
   });
@@ -99,18 +89,14 @@ export function transform(
   };
 }
 
-/**
- * @param {AstNode} ast
- * @param {string} code
- * @param {((specifier: string) => string | null) | null} resolve
- * @param {boolean} requireMode
- * @returns {{ isESM: boolean, preambleEnd: number }}
- */
-function doHoist(ast, code, resolve, requireMode) {
-  /** @type {AstNode[]} */
-  const declarations = [];
-  /** @type {AstNode[]} */
-  const body = [];
+function doHoist(
+  ast: AstNode,
+  code: string,
+  resolve: ((specifier: string) => string | null) | null,
+  requireMode: boolean,
+): { isESM: boolean; preambleEnd: number } {
+  const declarations: AstNode[] = [];
+  const body: AstNode[] = [];
 
   for (const node of ast.body) {
     if (isDeclaration(node)) {
@@ -139,10 +125,8 @@ function doHoist(ast, code, resolve, requireMode) {
   }
   const hasCJS = !hasAwait && !hasESM && hasRequire;
 
-  /** @type {string} */
-  let assertCode;
-  /** @type {boolean} */
-  let isESM;
+  let assertCode: string;
+  let isESM: boolean;
   if (hasESM) {
     assertCode = 'import assert from "node:assert/strict";';
     isESM = true;
@@ -157,18 +141,16 @@ function doHoist(ast, code, resolve, requireMode) {
 
   const assertNode = asNode(parseSync('t.js', assertCode).program.body[0]);
   const firstNode = declarations[0] || body[0];
-  if (firstNode)
-    stampLoc(assertNode, /** @type {SourceLocation} */ (firstNode.loc));
+  if (firstNode) stampLoc(assertNode, firstNode.loc as SourceLocation);
   ast.body = [assertNode, ...declarations, ...body];
 
   return { isESM, preambleEnd: 1 + declarations.length };
 }
 
-/**
- * @param {AstNode} node
- * @param {(specifier: string) => string | null} resolve
- */
-function renameSpecifiers(node, resolve) {
+function renameSpecifiers(
+  node: AstNode,
+  resolve: (specifier: string) => string | null,
+): void {
   const source = getSourceNode(node);
   if (source) renameStringLiteral(source, resolve);
   for (const call of findRequireCalls(node)) {
@@ -176,11 +158,10 @@ function renameSpecifiers(node, resolve) {
   }
 }
 
-/**
- * @param {AstNode} literal
- * @param {(specifier: string) => string | null} resolve
- */
-function renameStringLiteral(literal, resolve) {
+function renameStringLiteral(
+  literal: AstNode,
+  resolve: (specifier: string) => string | null,
+): void {
   const newPath = resolve(literal.value);
   if (newPath != null) {
     literal.value = newPath;
@@ -188,19 +169,18 @@ function renameStringLiteral(literal, resolve) {
   }
 }
 
-/**
- * @param {AstNode} ast
- * @param {Comment[]} comments
- * @param {string} code
- */
-function applyAssertions(ast, comments, code) {
+function applyAssertions(
+  ast: AstNode,
+  comments: Comment[],
+  code: string,
+): void {
   for (let i = 0; i < ast.body.length; i++) {
-    const node = /** @type {AstNode} */ (ast.body[i]);
+    const node = ast.body[i] as AstNode;
     if (node.type !== 'ExpressionStatement') continue;
 
     const comment = findTrailingComment(
       comments,
-      /** @type {AstNode & { expression: AstNode }} */ (node),
+      node as AstNode & { expression: AstNode },
       code,
     );
     if (!comment) continue;
@@ -216,8 +196,7 @@ function applyAssertions(ast, comments, code) {
       !throwsMatch &&
       comment.value.match(/^\s*rejects(?:\s+([\s\S]*))?$/);
 
-    /** @type {AstNode[] | undefined} */
-    let newNodes;
+    let newNodes: AstNode[] | undefined;
 
     if (match) {
       const rest = match[2].trim();
@@ -268,26 +247,23 @@ function applyAssertions(ast, comments, code) {
     }
 
     if (newNodes) {
-      for (const n of newNodes)
-        stampLoc(n, /** @type {SourceLocation} */ (node.loc));
+      for (const n of newNodes) stampLoc(n, node.loc as SourceLocation);
       ast.body.splice(i, 1, ...newNodes);
       i += newNodes.length - 1;
     }
   }
 }
 
-/**
- * @param {AstNode} ast
- * @param {Array<{ label: string, startLine: number, endLine: number }>} blocks
- * @param {number} preambleEnd
- * @param {boolean} isESM
- */
-function wrapInTest(ast, blocks, preambleEnd, isESM) {
+function wrapInTest(
+  ast: AstNode,
+  blocks: Array<{ label: string; startLine: number; endLine: number }>,
+  preambleEnd: number,
+  isESM: boolean,
+): void {
   const preamble = ast.body.slice(0, preambleEnd);
   const body = ast.body.slice(preambleEnd);
 
-  /** @type {Map<number, AstNode[]>} */
-  const groups = new Map();
+  const groups: Map<number, AstNode[]> = new Map();
   for (let i = 0; i < blocks.length; i++) groups.set(i, []);
 
   for (const node of body) {
@@ -295,7 +271,7 @@ function wrapInTest(ast, blocks, preambleEnd, isESM) {
     let placed = false;
     for (let i = 0; i < blocks.length; i++) {
       if (line >= blocks[i].startLine && line <= blocks[i].endLine) {
-        /** @type {AstNode[]} */ (groups.get(i)).push(node);
+        (groups.get(i) as AstNode[]).push(node);
         placed = true;
         break;
       }
@@ -305,13 +281,13 @@ function wrapInTest(ast, blocks, preambleEnd, isESM) {
 
   const testStmts = [];
   for (let i = 0; i < blocks.length; i++) {
-    const stmts = /** @type {AstNode[]} */ (groups.get(i));
+    const stmts = groups.get(i) as AstNode[];
     if (stmts.length === 0) continue;
     // Build wrapper with empty body, stamp it, then insert actual body.
     // This avoids stampLoc overwriting the inner nodes' source locations.
     const fn = arrow([], { async: true });
     const t = stmt(call(id('test'), [literal(blocks[i].label), fn]));
-    stampLoc(t, /** @type {SourceLocation} */ (stmts[0].loc));
+    stampLoc(t, stmts[0].loc as SourceLocation);
     fn.body.body = stmts;
     testStmts.push(t);
   }
@@ -321,17 +297,12 @@ function wrapInTest(ast, blocks, preambleEnd, isESM) {
     : 'const { test } = require("node:test");';
   const testImport = asNode(parseSync('t.js', testCode).program.body[0]);
   const firstNode = preamble[0] || testStmts[0];
-  if (firstNode?.loc)
-    stampLoc(testImport, /** @type {SourceLocation} */ (firstNode.loc));
+  if (firstNode?.loc) stampLoc(testImport, firstNode.loc as SourceLocation);
 
   ast.body = [testImport, ...preamble, ...testStmts];
 }
 
-/**
- * @param {AstNode} node
- * @returns {string}
- */
-function equalMethod(node) {
+function equalMethod(node: AstNode): string {
   if (node.type === 'Literal') return 'strictEqual';
   if (node.type === 'Identifier' && node.name === 'undefined')
     return 'strictEqual';
@@ -340,11 +311,7 @@ function equalMethod(node) {
 
 // --- AST node builders ---
 
-/**
- * @param {string} text
- * @returns {AstNode}
- */
-function parseExpr(text) {
+function parseExpr(text: string): AstNode {
   const result = parseSync('t.js', `(${text})`, { preserveParens: false });
   if (result.errors.length)
     throw new Error(`Invalid assertion expression: ${text}`);
@@ -354,28 +321,15 @@ function parseExpr(text) {
     : exprStmt.expression;
 }
 
-/**
- * @param {string} name
- * @returns {AstNode}
- */
-function id(name) {
+function id(name: string): AstNode {
   return { type: 'Identifier', name };
 }
 
-/**
- * @param {string} value
- * @returns {AstNode}
- */
-function literal(value) {
+function literal(value: string): AstNode {
   return { type: 'Literal', value, raw: JSON.stringify(value) };
 }
 
-/**
- * @param {AstNode} obj
- * @param {string} prop
- * @returns {AstNode}
- */
-function member(obj, prop) {
+function member(obj: AstNode, prop: string): AstNode {
   return {
     type: 'MemberExpression',
     object: obj,
@@ -385,37 +339,25 @@ function member(obj, prop) {
   };
 }
 
-/**
- * @param {AstNode} callee
- * @param {AstNode[]} args
- * @returns {AstNode}
- */
-function call(callee, args) {
+function call(callee: AstNode, args: AstNode[]): AstNode {
   return { type: 'CallExpression', callee, arguments: args };
 }
 
-/**
- * @param {AstNode} expr
- * @returns {AstNode}
- */
-function stmt(expr) {
+function stmt(expr: AstNode): AstNode {
   return { type: 'ExpressionStatement', expression: expr };
 }
 
-/**
- * @param {AstNode} arg
- * @returns {AstNode}
- */
-function awaitNode(arg) {
+function awaitNode(arg: AstNode): AstNode {
   return { type: 'AwaitExpression', argument: arg };
 }
 
-/**
- * @param {AstNode | AstNode[]} body
- * @param {{ async?: boolean, expression?: boolean }} [options]
- * @returns {AstNode}
- */
-function arrow(body, { async: isAsync = false, expression = false } = {}) {
+function arrow(
+  body: AstNode | AstNode[],
+  {
+    async: isAsync = false,
+    expression = false,
+  }: { async?: boolean; expression?: boolean } = {},
+): AstNode {
   return {
     type: 'ArrowFunctionExpression',
     params: [],
@@ -425,12 +367,7 @@ function arrow(body, { async: isAsync = false, expression = false } = {}) {
   };
 }
 
-/**
- * @param {string} key
- * @param {AstNode} value
- * @returns {AstNode}
- */
-function prop(key, value) {
+function prop(key: string, value: AstNode): AstNode {
   return {
     type: 'Property',
     key: id(key),
@@ -442,29 +379,15 @@ function prop(key, value) {
   };
 }
 
-/**
- * @param {AstNode[]} properties
- * @returns {AstNode}
- */
-function obj(properties) {
+function obj(properties: AstNode[]): AstNode {
   return { type: 'ObjectExpression', properties };
 }
 
-/**
- * @param {string} method
- * @param {AstNode[]} args
- * @returns {AstNode}
- */
-function assertCall(method, args) {
+function assertCall(method: string, args: AstNode[]): AstNode {
   return call(member(id('assert'), method), args);
 }
 
-/**
- * @param {string} name
- * @param {string | undefined} message
- * @returns {AstNode}
- */
-function errorMatcher(name, message) {
+function errorMatcher(name: string, message: string | undefined): AstNode {
   const props = [prop('name', literal(name))];
   if (message) {
     const reMatch = message.match(/^\/(.+)\/([gimsuy]*)$/);
@@ -475,13 +398,11 @@ function errorMatcher(name, message) {
   return obj(props);
 }
 
-/**
- * @param {AstNode} expr
- * @param {AstNode | null} matcher
- * @param {{ isAwait: boolean, useRejects: boolean }} options
- * @returns {AstNode}
- */
-function throwsOrRejects(expr, matcher, { isAwait, useRejects }) {
+function throwsOrRejects(
+  expr: AstNode,
+  matcher: AstNode | null,
+  { isAwait, useRejects }: { isAwait: boolean; useRejects: boolean },
+): AstNode {
   if (isAwait || useRejects) {
     const fn = isAwait
       ? arrow([stmt(expr)], { async: true })

--- a/test/comment-to-assert.test.ts
+++ b/test/comment-to-assert.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { commentToAssert } from '../src/transform.js';
-import { parse, assertCall, assertAwaitedCall, methodName } from './helpers.js';
+import { commentToAssert } from '../src/transform.ts';
+import { parse, assertCall, assertAwaitedCall, methodName } from './helpers.ts';
 
 describe('commentToAssert', () => {
   it('transforms //=> to assert.strictEqual for primitives', () => {
@@ -50,10 +50,12 @@ describe('commentToAssert', () => {
       commentToAssert('console.log(a) //=> { a: 1 }').code,
     ).body;
     const calls = body
-      .filter((n) => n.type === 'ExpressionStatement')
-      .map((n) => n.expression);
-    assert.ok(calls.some((c) => c.callee?.object?.name === 'console'));
-    assert.ok(calls.some((c) => methodName(c) === 'assert.deepStrictEqual'));
+      .filter((n: any) => n.type === 'ExpressionStatement')
+      .map((n: any) => n.expression);
+    assert.ok(calls.some((c: any) => c.callee?.object?.name === 'console'));
+    assert.ok(
+      calls.some((c: any) => methodName(c) === 'assert.deepStrictEqual'),
+    );
   });
 
   it('console.log with multiple statements', () => {
@@ -61,9 +63,9 @@ describe('commentToAssert', () => {
       commentToAssert('console.log(a) //=> 1\nlet b = 2;\nb; //=> 2').code,
     ).body;
     const calls = body
-      .filter((n) => n.type === 'ExpressionStatement')
-      .map((n) => n.expression)
-      .filter((e) => e.type === 'CallExpression');
+      .filter((n: any) => n.type === 'ExpressionStatement')
+      .map((n: any) => n.expression)
+      .filter((e: any) => e.type === 'CallExpression');
     const methods = calls.map(methodName);
     assert.ok(methods.includes('assert.strictEqual'));
     assert.ok(methods.includes('console.log'));
@@ -113,19 +115,19 @@ describe('commentToAssert', () => {
     const { code } = commentToAssert('x //=>\n');
     const body = parse(code).body;
     const calls = body
-      .filter((n) => n.type === 'ExpressionStatement')
-      .map((n) => n.expression)
-      .filter((e) => e.type === 'CallExpression');
+      .filter((n: any) => n.type === 'ExpressionStatement')
+      .map((n: any) => n.expression)
+      .filter((e: any) => e.type === 'CallExpression');
     assert.equal(calls.length, 0);
   });
 
   it('handles multiple assertions', () => {
     const body = parse(commentToAssert('a //=> 1\nb //=> 2').code).body;
     const calls = body
-      .filter((n) => n.type === 'ExpressionStatement')
-      .map((n) => n.expression);
+      .filter((n: any) => n.type === 'ExpressionStatement')
+      .map((n: any) => n.expression);
     assert.equal(calls.length, 2);
-    assert.ok(calls.every((c) => methodName(c) === 'assert.strictEqual'));
+    assert.ok(calls.every((c: any) => methodName(c) === 'assert.strictEqual'));
   });
 
   it('leaves regular comments alone', () => {
@@ -273,7 +275,7 @@ describe('commentToAssert', () => {
     assert.equal(methodName(call), 'assert.throws');
     const matcher = call.arguments[1];
     const msgProp = matcher.properties.find(
-      (p) => p.key.name === 'message' || p.key.value === 'message',
+      (p: any) => p.key.name === 'message' || p.key.value === 'message',
     );
     assert.ok(msgProp.value.value.includes('"foo"'));
   });

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractBlocks } from '../src/extract.js';
+import { extractBlocks } from '../src/extract.ts';
 
 describe('extractBlocks', () => {
   it('extracts tagged test blocks', () => {

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { generate } from '../src/generate.js';
+import { generate } from '../src/generate.ts';
 
 describe('generate', () => {
   it('produces one unit per ungrouped block', () => {
@@ -11,6 +11,7 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 3,
           endLine: 3,
         },
@@ -19,11 +20,11 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 7,
           endLine: 7,
         },
       ],
-      hasTypescript: false,
     });
     assert.equal(units.length, 2);
     assert.ok(units[0].code.includes('a; //=> 1'));
@@ -39,6 +40,7 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test:math',
           group: 'math',
+          description: null,
           startLine: 3,
           endLine: 3,
         },
@@ -47,11 +49,11 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test:math',
           group: 'math',
+          description: null,
           startLine: 7,
           endLine: 7,
         },
       ],
-      hasTypescript: false,
     });
     assert.equal(units.length, 1);
     assert.ok(units[0].code.includes('let x = 1;'));
@@ -67,6 +69,7 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 3,
           endLine: 3,
         },
@@ -75,6 +78,7 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test:g1',
           group: 'g1',
+          description: null,
           startLine: 7,
           endLine: 7,
         },
@@ -83,11 +87,11 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test:g1',
           group: 'g1',
+          description: null,
           startLine: 11,
           endLine: 11,
         },
       ],
-      hasTypescript: false,
     });
     assert.equal(units.length, 2);
     assert.ok(units[0].code.includes('a; //=> 1'));
@@ -103,11 +107,11 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 3,
           endLine: 3,
         },
       ],
-      hasTypescript: false,
     });
     const lines = units[0].code.split('\n');
     assert.equal(lines[2], 'a; //=> 1');
@@ -122,11 +126,11 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 3,
           endLine: 4,
         },
       ],
-      hasTypescript: false,
     });
     const lines = units[0].code.split('\n');
     const importLine = lines.findIndex((l) => l.includes('from "bar"'));
@@ -137,7 +141,7 @@ describe('generate', () => {
   });
 
   it('returns empty units for no blocks', () => {
-    const { units } = generate({ blocks: [], hasTypescript: false });
+    const { units } = generate({ blocks: [] });
     assert.equal(units.length, 0);
   });
 
@@ -149,6 +153,7 @@ describe('generate', () => {
           lang: 'javascript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 3,
           endLine: 3,
         },
@@ -157,11 +162,11 @@ describe('generate', () => {
           lang: 'typescript',
           tag: 'test',
           group: null,
+          description: null,
           startLine: 7,
           endLine: 7,
         },
       ],
-      hasTypescript: true,
     });
     assert.equal(units[0].hasTypescript, false);
     assert.equal(units[1].hasTypescript, true);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,17 +1,17 @@
 import assert from 'node:assert/strict';
 import { parseSync } from 'oxc-parser';
 
-export function parse(code, { typescript = false } = {}) {
+export function parse(code: string, { typescript = false } = {}): any {
   return parseSync(typescript ? 't.ts' : 't.js', code).program;
 }
 
-export function methodName(call) {
+export function methodName(call: any): string {
   return `${call.callee.object?.name}.${call.callee.property?.name}`;
 }
 
-export function assertCall(code) {
+export function assertCall(code: string) {
   const body = parse(code).body;
-  const stmt = body.find((n) => n.type === 'ExpressionStatement');
+  const stmt: any = body.find((n: any) => n.type === 'ExpressionStatement');
   const expr =
     stmt?.expression?.type === 'AwaitExpression'
       ? stmt.expression.argument
@@ -20,15 +20,17 @@ export function assertCall(code) {
   return expr;
 }
 
-export function assertAwaitedCall(code) {
-  const stmt = parse(code).body.find((n) => n.type === 'ExpressionStatement');
+export function assertAwaitedCall(code: string) {
+  const stmt: any = parse(code).body.find(
+    (n: any) => n.type === 'ExpressionStatement',
+  );
   assert.equal(stmt.expression.type, 'AwaitExpression');
   const call = stmt.expression.argument;
   assert.equal(call.type, 'CallExpression');
   return call;
 }
 
-export function assembled(startLine, code) {
+export function assembled(startLine: number, code: string): string {
   const codeLines = code.replace(/\n$/, '').split('\n');
   const maxLine = startLine + codeLines.length - 1;
   const lines = new Array(maxLine).fill('');

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,10 +2,10 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
-import { processMarkdown, run } from '../src/run.js';
-import { resolveMainEntry, resolveSubpathExport } from '../src/resolve.js';
+import { processMarkdown, run } from '../src/run.ts';
+import { resolveMainEntry, resolveSubpathExport } from '../src/resolve.ts';
 
-const cliPath = new URL('../src/cli.js', import.meta.url).pathname;
+const cliPath = new URL('../src/cli.ts', import.meta.url).pathname;
 
 const fixturesDir = new URL('./fixtures/', import.meta.url).pathname;
 
@@ -66,7 +66,7 @@ describe('processMarkdown', () => {
   it('throws NO_TEST_BLOCKS when the readme has no test blocks', async () => {
     await assert.rejects(
       () => processMarkdown(path.join(fixturesDir, 'no-blocks.md')),
-      (err) => {
+      (err: any) => {
         assert.equal(err.code, 'NO_TEST_BLOCKS');
         assert.match(err.message, /no-blocks\.md/);
         return true;
@@ -118,7 +118,7 @@ describe('cli', () => {
     const readme = path.join(fixturesDir, 'stream-delay.md');
     const child = spawn('node', [cliPath, '-f', readme]);
     const start = Date.now();
-    let markerAt = null;
+    let markerAt: number | null = null;
     child.stdout.on('data', (chunk) => {
       if (markerAt === null && chunk.toString().includes('STREAM-MARKER')) {
         markerAt = Date.now() - start;
@@ -288,7 +288,7 @@ describe('resolveMainEntry', () => {
 
   it('returns null when no entry can be determined', () => {
     assert.equal(resolveMainEntry({}), null);
-    assert.equal(resolveMainEntry({ exports: null }), null);
+    assert.equal(resolveMainEntry({ exports: null as any }), null);
   });
 });
 

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,20 +1,22 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { transform } from '../src/transform.js';
-import { parse, methodName, assembled } from './helpers.js';
+import { transform } from '../src/transform.ts';
+import { parse, methodName, assembled } from './helpers.ts';
 
-function findCalls(code, opts) {
+function findCalls(code: string, opts?: any) {
   return parse(code, opts)
-    .body.filter((n) => n.type === 'ExpressionStatement')
-    .map((n) => {
+    .body.filter((n: any) => n.type === 'ExpressionStatement')
+    .map((n: any) => {
       const e = n.expression;
       return e.type === 'AwaitExpression' ? e.argument : e;
     })
-    .filter((e) => e?.type === 'CallExpression');
+    .filter((e: any) => e?.type === 'CallExpression');
 }
 
-function findImports(code, opts) {
-  return parse(code, opts).body.filter((n) => n.type === 'ImportDeclaration');
+function findImports(code: string, opts?: any) {
+  return parse(code, opts).body.filter(
+    (n: any) => n.type === 'ImportDeclaration',
+  );
 }
 
 describe('transform – import hoisting', () => {
@@ -24,8 +26,10 @@ describe('transform – import hoisting', () => {
       { hoistImports: true },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
-    assert.ok(imports.some((n) => n.source.value === 'bar'));
+    assert.ok(
+      imports.some((n: any) => n.source.value === 'node:assert/strict'),
+    );
+    assert.ok(imports.some((n: any) => n.source.value === 'bar'));
   });
 
   it('uses CJS assert when body has require()', () => {
@@ -34,7 +38,7 @@ describe('transform – import hoisting', () => {
       { hoistImports: true },
     );
     const body = parse(code).body;
-    const decl = body.find((n) => n.type === 'VariableDeclaration');
+    const decl = body.find((n: any) => n.type === 'VariableDeclaration');
     assert.ok(decl);
     assert.equal(decl.declarations[0].init.callee?.name, 'require');
     assert.equal(
@@ -48,7 +52,7 @@ describe('transform – import hoisting', () => {
       hoistImports: true,
     });
     const body = parse(code).body;
-    const decl = body.find((n) => n.type === 'VariableDeclaration');
+    const decl = body.find((n: any) => n.type === 'VariableDeclaration');
     assert.ok(decl);
     const init = decl.declarations[0].init;
     // Should be `await import(...)` — the init is an AwaitExpression wrapping an ImportExpression
@@ -62,10 +66,12 @@ describe('transform – import hoisting', () => {
       { hoistImports: true },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === 'x'));
-    assert.ok(imports.some((n) => n.source.value === 'y'));
+    assert.ok(imports.some((n: any) => n.source.value === 'x'));
+    assert.ok(imports.some((n: any) => n.source.value === 'y'));
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
+      findCalls(code).some(
+        (c: any) => c.callee?.property?.name === 'strictEqual',
+      ),
     );
   });
 });
@@ -80,7 +86,7 @@ describe('transform – typescript mode', () => {
     );
     assert.ok(
       findCalls(code, ts).some(
-        (c) => c.callee?.property?.name === 'strictEqual',
+        (c: any) => c.callee?.property?.name === 'strictEqual',
       ),
     );
   });
@@ -91,8 +97,10 @@ describe('transform – typescript mode', () => {
       { hoistImports: true, ...ts },
     );
     const imports = findImports(code, ts);
-    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
-    assert.ok(imports.some((n) => n.source.value === 'bar'));
+    assert.ok(
+      imports.some((n: any) => n.source.value === 'node:assert/strict'),
+    );
+    assert.ok(imports.some((n: any) => n.source.value === 'bar'));
   });
 });
 
@@ -104,7 +112,7 @@ describe('transform – requireMode', () => {
     });
     assert.equal(isESM, false);
     const body = parse(code).body;
-    const decl = body.find((n) => n.type === 'VariableDeclaration');
+    const decl = body.find((n: any) => n.type === 'VariableDeclaration');
     assert.ok(decl);
     assert.equal(decl.declarations[0].init.callee?.name, 'require');
     assert.equal(
@@ -120,7 +128,9 @@ describe('transform – requireMode', () => {
     );
     assert.equal(isESM, true);
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
+    assert.ok(
+      imports.some((n: any) => n.source.value === 'node:assert/strict'),
+    );
   });
 });
 
@@ -132,7 +142,7 @@ describe('transform – export declarations', () => {
     );
     assert.equal(isESM, true);
     const exports = parse(code).body.filter(
-      (n) => n.type === 'ExportAllDeclaration',
+      (n: any) => n.type === 'ExportAllDeclaration',
     );
     assert.equal(exports.length, 1);
     assert.equal(exports[0].source.value, 'lib');
@@ -145,32 +155,32 @@ describe('transform – export declarations', () => {
     );
     assert.equal(isESM, true);
     const exports = parse(code).body.filter(
-      (n) => n.type === 'ExportNamedDeclaration' && n.source,
+      (n: any) => n.type === 'ExportNamedDeclaration' && n.source,
     );
     assert.equal(exports.length, 1);
     assert.equal(exports[0].source.value, 'lib');
   });
 
   it('renames export * from source via resolve function', () => {
-    const resolve = (s) => (s === 'lib' ? '/abs/lib.js' : null);
+    const resolve = (s: any) => (s === 'lib' ? '/abs/lib.js' : null);
     const { code } = transform(
       assembled(3, 'export * from "lib";\nfoo() //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const exports = parse(code).body.filter(
-      (n) => n.type === 'ExportAllDeclaration',
+      (n: any) => n.type === 'ExportAllDeclaration',
     );
     assert.equal(exports[0].source.value, '/abs/lib.js');
   });
 
   it('renames export { x } from source via resolve function', () => {
-    const resolve = (s) => (s === 'lib' ? '/abs/lib.js' : null);
+    const resolve = (s: any) => (s === 'lib' ? '/abs/lib.js' : null);
     const { code } = transform(
       assembled(3, 'export { foo } from "lib";\nbar() //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const exports = parse(code).body.filter(
-      (n) => n.type === 'ExportNamedDeclaration' && n.source,
+      (n: any) => n.type === 'ExportNamedDeclaration' && n.source,
     );
     assert.equal(exports[0].source.value, '/abs/lib.js');
   });
@@ -178,36 +188,41 @@ describe('transform – export declarations', () => {
 
 describe('transform – import renaming', () => {
   it('renames ESM import source via resolve function', () => {
-    const resolve = (s) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
+    const resolve = (s: any) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { foo } from "my-pkg";\nfoo //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === '/abs/path/index.js'));
-    assert.ok(!imports.some((n) => n.source.value === 'my-pkg'));
+    assert.ok(
+      imports.some((n: any) => n.source.value === '/abs/path/index.js'),
+    );
+    assert.ok(!imports.some((n: any) => n.source.value === 'my-pkg'));
   });
 
   it('renames subpath imports', () => {
-    const resolve = (s) => (s === 'my-pkg/utils' ? '/abs/path/utils.js' : null);
+    const resolve = (s: any) =>
+      s === 'my-pkg/utils' ? '/abs/path/utils.js' : null;
     const { code } = transform(
       assembled(3, 'import { bar } from "my-pkg/utils";\nbar //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     assert.ok(
-      findImports(code).some((n) => n.source.value === '/abs/path/utils.js'),
+      findImports(code).some(
+        (n: any) => n.source.value === '/abs/path/utils.js',
+      ),
     );
   });
 
   it('renames require() calls in body', () => {
-    const resolve = (s) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
+    const resolve = (s: any) => (s === 'my-pkg' ? '/abs/path/index.js' : null);
     const { code } = transform(
       assembled(3, 'const x = require("my-pkg");\nx //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const body = parse(code).body;
     const decl = body.find(
-      (n) =>
+      (n: any) =>
         n.type === 'VariableDeclaration' &&
         n.declarations[0]?.init?.callee?.name === 'require' &&
         n.declarations[0]?.init?.arguments[0]?.value !== 'node:assert/strict',
@@ -220,13 +235,15 @@ describe('transform – import renaming', () => {
   });
 
   it('handles $ in resolved file paths', () => {
-    const resolve = (s) => (s === 'my-pkg' ? '/path/$1/index.js' : null);
+    const resolve = (s: any) => (s === 'my-pkg' ? '/path/$1/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { foo } from "my-pkg";\nfoo //=> 1\n'),
       { hoistImports: true, renameImports: resolve },
     );
     assert.ok(
-      findImports(code).some((n) => n.source.value === '/path/$1/index.js'),
+      findImports(code).some(
+        (n: any) => n.source.value === '/path/$1/index.js',
+      ),
     );
   });
 });
@@ -237,7 +254,9 @@ describe('transform – assertion comments', () => {
       hoistImports: true,
     });
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
+      findCalls(code).some(
+        (c: any) => c.callee?.property?.name === 'strictEqual',
+      ),
     );
   });
 
@@ -247,11 +266,11 @@ describe('transform – assertion comments', () => {
       { hoistImports: true },
     );
     const throwsCall = findCalls(code).find(
-      (c) => c.callee?.property?.name === 'throws',
+      (c: any) => c.callee?.property?.name === 'throws',
     );
     assert.ok(throwsCall);
     const msgProp = throwsCall.arguments[1].properties.find(
-      (p) => p.key.name === 'message' || p.key.value === 'message',
+      (p: any) => p.key.name === 'message' || p.key.value === 'message',
     );
     assert.ok(msgProp.value.value.includes('"foo"'));
   });
@@ -262,10 +281,10 @@ describe('transform – assertion comments', () => {
       { hoistImports: true },
     );
     const throwsCall = findCalls(code).find(
-      (c) => c.callee?.property?.name === 'throws',
+      (c: any) => c.callee?.property?.name === 'throws',
     );
     const msgProp = throwsCall.arguments[1].properties.find(
-      (p) => p.key.name === 'message' || p.key.value === 'message',
+      (p: any) => p.key.name === 'message' || p.key.value === 'message',
     );
     assert.ok(msgProp.value.value.includes('path\\to\\file'));
   });
@@ -293,16 +312,20 @@ describe('transform – sourcemaps', () => {
 
 describe('transform – combined', () => {
   it('renames, hoists, and transforms assertions in one pass', () => {
-    const resolve = (s) => (s === 'my-pkg' ? '/src/index.js' : null);
+    const resolve = (s: any) => (s === 'my-pkg' ? '/src/index.js' : null);
     const { code } = transform(
       assembled(3, 'import { add } from "my-pkg";\nadd(1, 2) //=> 3\n'),
       { hoistImports: true, renameImports: resolve },
     );
     const imports = findImports(code);
-    assert.ok(imports.some((n) => n.source.value === 'node:assert/strict'));
-    assert.ok(imports.some((n) => n.source.value === '/src/index.js'));
     assert.ok(
-      findCalls(code).some((c) => c.callee?.property?.name === 'strictEqual'),
+      imports.some((n: any) => n.source.value === 'node:assert/strict'),
+    );
+    assert.ok(imports.some((n: any) => n.source.value === '/src/index.js'));
+    assert.ok(
+      findCalls(code).some(
+        (c: any) => c.callee?.property?.name === 'strictEqual',
+      ),
     );
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "checkJs": true,
-    "allowJs": true,
-    "noEmit": true,
     "strict": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "target": "es2022",
+    "noEmit": true,
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true,
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary

- Rename all `.js` source and test files to `.ts`
- Convert JSDoc type annotations to proper TypeScript syntax
- All types are erasable (`erasableSyntaxOnly`) — no enums, namespaces, or parameter properties
- `tsconfig.json` typechecks `src/` and `test/` with `noEmit`
- `tsconfig.build.json` emits `dist/` with `.js` + `.d.ts` for publishing
- Tests run `.ts` directly via Node's native type stripping
- `prepublishOnly` runs the build
- CI updated with build step

Net result: -129 lines (383 insertions, 512 deletions) — JSDoc boilerplate replaced with inline annotations.

## Test plan

- [x] `npm run typecheck` — src + test pass
- [x] `npm run build` — emits dist/ with .js + .d.ts
- [x] 120 unit tests pass
- [x] 4 README assertion blocks pass
- [x] All 15 example projects pass
- [x] Format clean